### PR TITLE
Add customer header with cart badge and navigation

### DIFF
--- a/src/app/(customer)/cart/page.tsx
+++ b/src/app/(customer)/cart/page.tsx
@@ -16,6 +16,7 @@ export default function CartPage() {
   function updateCart(newCart: CartItemType[]) {
     setCart(newCart);
     localStorage.setItem("cart", JSON.stringify(newCart));
+    window.dispatchEvent(new Event("cart-updated"));
   }
 
   function handleUpdateQuantity(id: string, quantity: number) {
@@ -48,24 +49,34 @@ export default function CartPage() {
           </Link>
         </div>
       ) : (
-        <div className="rounded-lg bg-white p-4 shadow-sm">
-          {cart.map((item) => (
-            <CartItem
-              key={item.id}
-              {...item}
-              onUpdateQuantity={handleUpdateQuantity}
-              onRemove={handleRemove}
-            />
-          ))}
-          <div className="mt-4 flex items-center justify-between border-t pt-4">
-            <span className="text-lg font-bold">
-              合計: ¥{total.toLocaleString()}
-            </span>
+        <div>
+          <div className="rounded-lg bg-white p-4 shadow-sm">
+            {cart.map((item) => (
+              <CartItem
+                key={item.id}
+                {...item}
+                onUpdateQuantity={handleUpdateQuantity}
+                onRemove={handleRemove}
+              />
+            ))}
+            <div className="mt-4 flex items-center justify-between border-t pt-4">
+              <span className="text-lg font-bold">
+                合計: ¥{total.toLocaleString()}
+              </span>
+              <Link
+                href="/address"
+                className="rounded-full bg-orange-500 px-6 py-2 text-white hover:bg-orange-600"
+              >
+                注文へ進む
+              </Link>
+            </div>
+          </div>
+          <div className="mt-4 text-center">
             <Link
-              href="/address"
-              className="rounded-full bg-orange-500 px-6 py-2 text-white hover:bg-orange-600"
+              href="/products"
+              className="text-orange-500 underline"
             >
-              注文へ進む
+              買い物を続ける
             </Link>
           </div>
         </div>

--- a/src/app/(customer)/layout.tsx
+++ b/src/app/(customer)/layout.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { LiffProvider } from "@/components/liff-provider";
+import { CustomerHeader } from "@/components/customer-header";
 
 export default function CustomerLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <LiffProvider>{children}</LiffProvider>;
+  return (
+    <LiffProvider>
+      <CustomerHeader />
+      {children}
+    </LiffProvider>
+  );
 }

--- a/src/app/(customer)/products/page.tsx
+++ b/src/app/(customer)/products/page.tsx
@@ -6,6 +6,7 @@ import type { Product } from "@/types";
 
 export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
+  const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/products")
@@ -30,7 +31,10 @@ export default function ProductsPage() {
       });
     }
     localStorage.setItem("cart", JSON.stringify(cart));
-    alert("カートに追加しました");
+    window.dispatchEvent(new Event("cart-updated"));
+
+    setToast("カートに追加しました");
+    setTimeout(() => setToast(null), 2000);
   }
 
   return (
@@ -47,6 +51,11 @@ export default function ProductsPage() {
       </div>
       {products.length === 0 && (
         <p className="text-center text-gray-500">商品を読み込み中...</p>
+      )}
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 rounded-full bg-gray-800 px-6 py-3 text-sm text-white shadow-lg">
+          {toast}
+        </div>
       )}
     </div>
   );

--- a/src/components/customer-header.tsx
+++ b/src/components/customer-header.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { CartItemType } from "@/types";
+
+export function CustomerHeader() {
+  const [itemCount, setItemCount] = useState(0);
+
+  useEffect(() => {
+    function updateCount() {
+      const cart: CartItemType[] = JSON.parse(
+        localStorage.getItem("cart") ?? "[]"
+      );
+      setItemCount(cart.reduce((sum, item) => sum + item.quantity, 0));
+    }
+
+    updateCount();
+
+    // Listen for custom event from same tab
+    window.addEventListener("cart-updated", updateCount);
+    // Listen for storage event from other tabs
+    window.addEventListener("storage", (e) => {
+      if (e.key === "cart") updateCount();
+    });
+
+    return () => {
+      window.removeEventListener("cart-updated", updateCount);
+      window.removeEventListener("storage", updateCount);
+    };
+  }, []);
+
+  return (
+    <header className="sticky top-0 z-10 flex items-center justify-between bg-orange-500 px-4 py-3 text-white shadow-md">
+      <Link href="/products" className="text-lg font-bold">
+        みかん農園
+      </Link>
+      <Link href="/cart" className="relative">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"
+          />
+        </svg>
+        {itemCount > 0 && (
+          <span className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold">
+            {itemCount}
+          </span>
+        )}
+      </Link>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- 共通ヘッダーコンポーネント追加（カートアイコン+バッジ）
- alert()をトースト通知に置き換え
- カートページに「買い物を続ける」リンク追加
- cart-updatedイベントでヘッダーバッジをリアルタイム同期

## Test plan
- [ ] `/products`でヘッダーにカートアイコンが表示される
- [ ] 商品追加時にトースト表示、バッジ数が増える
- [ ] カートアイコンクリックで`/cart`に遷移
- [ ] カートページで数量変更・削除時にバッジ連動

🤖 Generated with [Claude Code](https://claude.com/claude-code)