### PR TITLE
Move admin auth to server-side with HTTPOnly cookie

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useState } from "react";
 import Link from "next/link";
 
 export default function AdminLayout({
@@ -8,42 +5,6 @@ export default function AdminLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [authenticated, setAuthenticated] = useState(false);
-  const [password, setPassword] = useState("");
-
-  if (!authenticated) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (password === process.env.NEXT_PUBLIC_ADMIN_PASSWORD) {
-              setAuthenticated(true);
-            } else {
-              alert("パスワードが正しくありません");
-            }
-          }}
-          className="w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow"
-        >
-          <h1 className="text-xl font-bold">管理画面ログイン</h1>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="パスワード"
-            className="w-full rounded border p-2"
-          />
-          <button
-            type="submit"
-            className="w-full rounded bg-gray-800 py-2 text-white hover:bg-gray-900"
-          >
-            ログイン
-          </button>
-        </form>
-      </div>
-    );
-  }
-
   return (
     <div className="min-h-screen bg-gray-50">
       <nav className="border-b bg-white px-6 py-3">

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AdminLoginPage() {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/admin/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+
+      if (res.ok) {
+        router.push("/admin/orders");
+      } else {
+        const data = await res.json();
+        setError(data.error || "ログインに失敗しました");
+      }
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow"
+      >
+        <h1 className="text-xl font-bold">管理画面ログイン</h1>
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="パスワード"
+          className="w-full rounded border p-2"
+          disabled={loading}
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded bg-gray-800 py-2 text-white hover:bg-gray-900 disabled:opacity-50"
+        >
+          {loading ? "ログイン中..." : "ログイン"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import crypto from "crypto";
+
+function generateSessionToken(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+export async function POST(request: NextRequest) {
+  const { password } = await request.json();
+
+  if (password !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json(
+      { error: "パスワードが正しくありません" },
+      { status: 401 }
+    );
+  }
+
+  const token = generateSessionToken();
+  const cookieStore = await cookies();
+
+  cookieStore.set("admin_session", token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24, // 24 hours
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Skip login page and login API
+  if (pathname === "/admin/login" || pathname === "/api/admin/login") {
+    return NextResponse.next();
+  }
+
+  // Protect /admin/* routes
+  if (pathname.startsWith("/admin")) {
+    const session = request.cookies.get("admin_session");
+    if (!session?.value) {
+      return NextResponse.redirect(new URL("/admin/login", request.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin/:path*", "/api/admin/:path*"],
+};


### PR DESCRIPTION
## Summary
- Replace client-side password check (`NEXT_PUBLIC_ADMIN_PASSWORD` exposure) with server-side session-based auth
- Add `/api/admin/login` route that validates password and sets HTTPOnly cookie
- Add Next.js middleware to protect `/admin/*` routes, redirecting unauthenticated users to `/admin/login`
- Remove client-side auth gate from `admin/layout.tsx`, convert to server component

## Test plan
- [ ] Accessing `/admin/orders` without login redirects to `/admin/login`
- [ ] Correct password sets HTTPOnly cookie and redirects to `/admin/orders`
- [ ] Wrong password shows error message
- [ ] `ADMIN_PASSWORD` is not exposed to the client

🤖 Generated with [Claude Code](https://claude.com/claude-code)