### PR TITLE
feat: 住所の保存・自動入力機能を追加

### DIFF
--- a/src/app/(customer)/address/page.tsx
+++ b/src/app/(customer)/address/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useLiff } from "@/components/liff-provider";
 import { addressSchema } from "@/lib/validations";
@@ -24,6 +24,41 @@ export default function AddressPage() {
   >("cash_on_delivery");
   const [submitting, setSubmitting] = useState(false);
   const [errors, setErrors] = useState<FieldErrors>({});
+  const [loadingAddress, setLoadingAddress] = useState(true);
+
+  useEffect(() => {
+    if (!profile?.userId) {
+      setLoadingAddress(false);
+      return;
+    }
+
+    async function fetchSavedAddress() {
+      try {
+        const res = await fetch(
+          `/api/addresses?userId=${encodeURIComponent(profile!.userId)}`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.length > 0) {
+          const latest = data[0];
+          setForm({
+            postalCode: latest.postalCode ?? "",
+            prefecture: latest.prefecture ?? "",
+            city: latest.city ?? "",
+            line1: latest.line1 ?? "",
+            line2: latest.line2 ?? "",
+            phone: latest.phone ?? "",
+            recipientName: latest.recipientName ?? "",
+          });
+        }
+      } catch {
+        // 取得失敗時は空フォームのまま
+      } finally {
+        setLoadingAddress(false);
+      }
+    }
+    fetchSavedAddress();
+  }, [profile]);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -92,142 +127,148 @@ export default function AddressPage() {
       <h1 className="mb-6 text-2xl font-bold text-orange-600">
         配送先・お支払い
       </h1>
-      <form
-        onSubmit={handleSubmit}
-        className="space-y-4 rounded-lg bg-white p-4 shadow-sm"
-      >
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            受取人名
-          </label>
-          <input
-            name="recipientName"
-            value={form.recipientName}
-            onChange={handleChange}
-            className={fieldClass("recipientName")}
-          />
-          {errors.recipientName && (
-            <p className="mt-1 text-sm text-red-600">{errors.recipientName}</p>
-          )}
+      {loadingAddress ? (
+        <div className="flex justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-orange-300 border-t-orange-600" />
         </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            郵便番号
-          </label>
-          <input
-            name="postalCode"
-            value={form.postalCode}
-            onChange={handleChange}
-            placeholder="123-4567"
-            className={fieldClass("postalCode")}
-          />
-          {errors.postalCode && (
-            <p className="mt-1 text-sm text-red-600">{errors.postalCode}</p>
-          )}
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            都道府県
-          </label>
-          <input
-            name="prefecture"
-            value={form.prefecture}
-            onChange={handleChange}
-            className={fieldClass("prefecture")}
-          />
-          {errors.prefecture && (
-            <p className="mt-1 text-sm text-red-600">{errors.prefecture}</p>
-          )}
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            市区町村
-          </label>
-          <input
-            name="city"
-            value={form.city}
-            onChange={handleChange}
-            className={fieldClass("city")}
-          />
-          {errors.city && (
-            <p className="mt-1 text-sm text-red-600">{errors.city}</p>
-          )}
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            番地・建物名
-          </label>
-          <input
-            name="line1"
-            value={form.line1}
-            onChange={handleChange}
-            className={fieldClass("line1")}
-          />
-          {errors.line1 && (
-            <p className="mt-1 text-sm text-red-600">{errors.line1}</p>
-          )}
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            建物名・部屋番号（任意）
-          </label>
-          <input
-            name="line2"
-            value={form.line2}
-            onChange={handleChange}
-            className={fieldClass("line2")}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            電話番号
-          </label>
-          <input
-            name="phone"
-            value={form.phone}
-            onChange={handleChange}
-            placeholder="090-1234-5678"
-            className={fieldClass("phone")}
-          />
-          {errors.phone && (
-            <p className="mt-1 text-sm text-red-600">{errors.phone}</p>
-          )}
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-900">
-            お支払い方法
-          </label>
-          <div className="mt-2 space-y-2">
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="paymentMethod"
-                value="cash_on_delivery"
-                checked={paymentMethod === "cash_on_delivery"}
-                onChange={() => setPaymentMethod("cash_on_delivery")}
-              />
-              代金引換
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="paymentMethod"
-                value="bank_transfer"
-                checked={paymentMethod === "bank_transfer"}
-                onChange={() => setPaymentMethod("bank_transfer")}
-              />
-              銀行振込
-            </label>
-          </div>
-        </div>
-        <button
-          type="submit"
-          disabled={submitting}
-          className="w-full rounded-full bg-orange-500 py-3 font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 rounded-lg bg-white p-4 shadow-sm"
         >
-          {submitting ? "送信中..." : "注文を確定する"}
-        </button>
-      </form>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              受取人名
+            </label>
+            <input
+              name="recipientName"
+              value={form.recipientName}
+              onChange={handleChange}
+              className={fieldClass("recipientName")}
+            />
+            {errors.recipientName && (
+              <p className="mt-1 text-sm text-red-600">{errors.recipientName}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              郵便番号
+            </label>
+            <input
+              name="postalCode"
+              value={form.postalCode}
+              onChange={handleChange}
+              placeholder="123-4567"
+              className={fieldClass("postalCode")}
+            />
+            {errors.postalCode && (
+              <p className="mt-1 text-sm text-red-600">{errors.postalCode}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              都道府県
+            </label>
+            <input
+              name="prefecture"
+              value={form.prefecture}
+              onChange={handleChange}
+              className={fieldClass("prefecture")}
+            />
+            {errors.prefecture && (
+              <p className="mt-1 text-sm text-red-600">{errors.prefecture}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              市区町村
+            </label>
+            <input
+              name="city"
+              value={form.city}
+              onChange={handleChange}
+              className={fieldClass("city")}
+            />
+            {errors.city && (
+              <p className="mt-1 text-sm text-red-600">{errors.city}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              番地・建物名
+            </label>
+            <input
+              name="line1"
+              value={form.line1}
+              onChange={handleChange}
+              className={fieldClass("line1")}
+            />
+            {errors.line1 && (
+              <p className="mt-1 text-sm text-red-600">{errors.line1}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              建物名・部屋番号（任意）
+            </label>
+            <input
+              name="line2"
+              value={form.line2}
+              onChange={handleChange}
+              className={fieldClass("line2")}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              電話番号
+            </label>
+            <input
+              name="phone"
+              value={form.phone}
+              onChange={handleChange}
+              placeholder="090-1234-5678"
+              className={fieldClass("phone")}
+            />
+            {errors.phone && (
+              <p className="mt-1 text-sm text-red-600">{errors.phone}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              お支払い方法
+            </label>
+            <div className="mt-2 space-y-2">
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="paymentMethod"
+                  value="cash_on_delivery"
+                  checked={paymentMethod === "cash_on_delivery"}
+                  onChange={() => setPaymentMethod("cash_on_delivery")}
+                />
+                代金引換
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="paymentMethod"
+                  value="bank_transfer"
+                  checked={paymentMethod === "bank_transfer"}
+                  onChange={() => setPaymentMethod("bank_transfer")}
+                />
+                銀行振込
+              </label>
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-full bg-orange-500 py-3 font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+          >
+            {submitting ? "送信中..." : "注文を確定する"}
+          </button>
+        </form>
+      )}
     </div>
   );
 }

--- a/src/app/api/addresses/route.ts
+++ b/src/app/api/addresses/route.ts
@@ -1,22 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { addresses, users } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 
 export async function GET(request: NextRequest) {
-  const lineUserId = request.nextUrl.searchParams.get("userId");
-  if (!lineUserId) {
-    return NextResponse.json({ error: "userId required" }, { status: 400 });
+  try {
+    const lineUserId = request.nextUrl.searchParams.get("userId");
+    if (!lineUserId) {
+      return NextResponse.json({ error: "userId required" }, { status: 400 });
+    }
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.lineUserId, lineUserId),
+    });
+    if (!user) return NextResponse.json([]);
+
+    const userAddresses = await db
+      .select()
+      .from(addresses)
+      .where(eq(addresses.userId, user.id))
+      .orderBy(desc(addresses.createdAt));
+    return NextResponse.json(userAddresses);
+  } catch (e) {
+    console.error("Failed to fetch addresses:", e);
+    return NextResponse.json(
+      { error: "住所の取得に失敗しました" },
+      { status: 500 }
+    );
   }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.lineUserId, lineUserId),
-  });
-  if (!user) return NextResponse.json([]);
-
-  const userAddresses = await db
-    .select()
-    .from(addresses)
-    .where(eq(addresses.userId, user.id));
-  return NextResponse.json(userAddresses);
 }


### PR DESCRIPTION
## Summary
- 注文時に保存された住所をDBから取得し、次回注文時にフォームへ自動入力する機能を追加
- addresses APIに作成日降順ソートとエラーハンドリングを追加
- ページ読込中はローディングスピナーを表示

## Test plan
- [ ] 初回注文時（住所未保存）はフォームが空で表示されること
- [ ] 注文完了後、再度住所ページを開くと前回の住所が自動入力されること
- [ ] 複数回注文した場合、最新の住所が自動入力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)