### PR TITLE
feat: 注文詳細ページを追加

### DIFF
--- a/src/app/(customer)/orders/[id]/page.tsx
+++ b/src/app/(customer)/orders/[id]/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { OrderStatusBadge } from "@/components/order-status-badge";
+import type { Address } from "@/types";
+
+type OrderItemDetail = {
+  id: string;
+  productId: string;
+  productName: string;
+  productVariety: string;
+  quantity: number;
+  unitPriceJpy: number;
+};
+
+type OrderDetail = {
+  id: string;
+  status: string;
+  paymentMethod: string;
+  totalJpy: number;
+  note: string | null;
+  createdAt: string;
+  address: Address;
+  items: OrderItemDetail[];
+};
+
+const paymentLabels: Record<string, string> = {
+  bank_transfer: "銀行振込",
+  cash_on_delivery: "代金引換",
+};
+
+export default function OrderDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [order, setOrder] = useState<OrderDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/orders/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("注文詳細の取得に失敗しました");
+        return res.json();
+      })
+      .then(setOrder)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-orange-50">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-orange-300 border-t-orange-600" />
+      </div>
+    );
+  }
+
+  if (error || !order) {
+    return (
+      <div className="min-h-screen bg-orange-50 p-4">
+        <div className="rounded-lg bg-red-50 p-4 text-center text-red-600">
+          <p>{error ?? "注文が見つかりません"}</p>
+          <Link href="/orders" className="mt-2 inline-block text-sm underline">
+            注文履歴に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-orange-50 p-4">
+      <Link
+        href="/orders"
+        className="mb-4 inline-block text-sm text-orange-600 hover:underline"
+      >
+        ← 注文履歴に戻る
+      </Link>
+      <h1 className="mb-6 text-2xl font-bold text-orange-600">注文詳細</h1>
+
+      <div className="space-y-4">
+        {/* ステータス・基本情報 */}
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gray-500">
+              {new Date(order.createdAt).toLocaleDateString("ja-JP", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+            <OrderStatusBadge status={order.status} />
+          </div>
+          <p className="mt-2 text-sm text-gray-600">
+            お支払い: {paymentLabels[order.paymentMethod] ?? order.paymentMethod}
+          </p>
+        </div>
+
+        {/* 商品一覧 */}
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <h2 className="mb-3 font-bold text-gray-900">注文商品</h2>
+          <div className="divide-y">
+            {order.items.map((item) => (
+              <div key={item.id} className="flex items-center justify-between py-3">
+                <div>
+                  <p className="font-medium text-gray-900">{item.productName}</p>
+                  {item.productVariety && (
+                    <p className="text-sm text-gray-500">{item.productVariety}</p>
+                  )}
+                  <p className="text-sm text-gray-500">数量: {item.quantity}</p>
+                </div>
+                <p className="font-medium text-orange-600">
+                  ¥{(item.unitPriceJpy * item.quantity).toLocaleString()}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 border-t pt-3 text-right">
+            <span className="text-lg font-bold">
+              合計: ¥{order.totalJpy.toLocaleString()}
+            </span>
+          </div>
+        </div>
+
+        {/* 配送先 */}
+        <div className="rounded-lg bg-white p-4 shadow-sm">
+          <h2 className="mb-3 font-bold text-gray-900">配送先</h2>
+          <div className="space-y-1 text-sm text-gray-700">
+            <p className="font-medium">{order.address.recipientName}</p>
+            <p>〒{order.address.postalCode}</p>
+            <p>
+              {order.address.prefecture}
+              {order.address.city}
+              {order.address.line1}
+            </p>
+            {order.address.line2 && <p>{order.address.line2}</p>}
+            <p>TEL: {order.address.phone}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(customer)/orders/page.tsx
+++ b/src/app/(customer)/orders/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useLiff } from "@/components/liff-provider";
 import { OrderStatusBadge } from "@/components/order-status-badge";
 import type { Order } from "@/types";
@@ -48,17 +49,24 @@ export default function OrdersPage() {
       {!loading && !error && orders.length > 0 && (
         <div className="space-y-4">
           {orders.map((order) => (
-            <div key={order.id} className="rounded-lg bg-white p-4 shadow-sm">
+            <Link
+              key={order.id}
+              href={`/orders/${order.id}`}
+              className="block rounded-lg bg-white p-4 shadow-sm transition hover:shadow-md"
+            >
               <div className="flex items-center justify-between">
                 <span className="text-sm text-gray-500">
                   {new Date(order.createdAt).toLocaleDateString("ja-JP")}
                 </span>
                 <OrderStatusBadge status={order.status} />
               </div>
-              <p className="mt-2 text-lg font-bold">
-                ¥{order.totalJpy.toLocaleString()}
-              </p>
-            </div>
+              <div className="mt-2 flex items-center justify-between">
+                <p className="text-lg font-bold">
+                  ¥{order.totalJpy.toLocaleString()}
+                </p>
+                <span className="text-sm text-orange-600">詳細 →</span>
+              </div>
+            </Link>
           ))}
         </div>
       )}

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { orders, orderItems, products, addresses } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const order = await db.query.orders.findFirst({
+      where: eq(orders.id, id),
+      with: {
+        address: true,
+        items: true,
+      },
+    });
+
+    if (!order) {
+      return NextResponse.json(
+        { error: "注文が見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    const itemsWithProduct = await Promise.all(
+      order.items.map(async (item) => {
+        const product = await db.query.products.findFirst({
+          where: eq(products.id, item.productId),
+        });
+        return {
+          ...item,
+          productName: product?.name ?? "不明な商品",
+          productVariety: product?.variety ?? "",
+        };
+      })
+    );
+
+    return NextResponse.json({
+      ...order,
+      items: itemsWithProduct,
+    });
+  } catch (e) {
+    console.error("Failed to fetch order detail:", e);
+    return NextResponse.json(
+      { error: "注文詳細の取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- `/orders/[id]` で注文詳細（商品一覧・数量・金額・配送先・ステータス）を表示する新規ページを追加
- 注文履歴ページの各注文カードをクリックで詳細ページへ遷移できるようリンク化
- 注文詳細取得用API `/api/orders/[id]` を追加

## Test plan
- [ ] 注文履歴ページで注文をタップすると詳細ページに遷移すること
- [ ] 詳細ページに商品名・数量・金額・配送先・ステータスが表示されること
- [ ] 「注文履歴に戻る」リンクで一覧に戻れること
- [ ] 存在しない注文IDにアクセスした場合エラーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)