### PR TITLE
feat: 管理画面の商品CRUD機能を追加

### DIFF
--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -3,14 +3,115 @@
 import { useEffect, useState } from "react";
 import type { Product } from "@/types";
 
+type ProductForm = {
+  name: string;
+  variety: string;
+  weightGrams: string;
+  priceJpy: string;
+  description: string;
+  isAvailable: boolean;
+};
+
+const emptyForm: ProductForm = {
+  name: "",
+  variety: "",
+  weightGrams: "",
+  priceJpy: "",
+  description: "",
+  isAvailable: true,
+};
+
 export default function AdminProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<ProductForm>(emptyForm);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function fetchProducts() {
+    try {
+      const res = await fetch("/api/products?all=true");
+      const data = await res.json();
+      setProducts(data);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    fetch("/api/products")
-      .then((res) => res.json())
-      .then(setProducts);
+    fetchProducts();
   }, []);
+
+  function openAddForm() {
+    setEditingId(null);
+    setForm(emptyForm);
+    setShowForm(true);
+  }
+
+  function openEditForm(product: Product) {
+    setEditingId(product.id);
+    setForm({
+      name: product.name,
+      variety: product.variety,
+      weightGrams: String(product.weightGrams),
+      priceJpy: String(product.priceJpy),
+      description: product.description ?? "",
+      isAvailable: product.isAvailable,
+    });
+    setShowForm(true);
+  }
+
+  function cancelForm() {
+    setShowForm(false);
+    setEditingId(null);
+    setForm(emptyForm);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+
+    const payload = {
+      name: form.name,
+      variety: form.variety,
+      weightGrams: Number(form.weightGrams),
+      priceJpy: Number(form.priceJpy),
+      description: form.description || null,
+      isAvailable: form.isAvailable,
+    };
+
+    try {
+      if (editingId) {
+        await fetch("/api/products", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: editingId, ...payload }),
+        });
+      } else {
+        await fetch("/api/products", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      }
+      cancelForm();
+      await fetchProducts();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("この商品を削除しますか？")) return;
+
+    await fetch("/api/products", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    await fetchProducts();
+  }
 
   async function toggleAvailability(id: string, isAvailable: boolean) {
     await fetch("/api/products", {
@@ -27,35 +128,176 @@ export default function AdminProductsPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold">商品管理</h1>
-      {products.length === 0 ? (
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">商品管理</h1>
+        <button
+          onClick={openAddForm}
+          className="rounded bg-orange-500 px-4 py-2 text-sm font-medium text-white hover:bg-orange-600"
+        >
+          + 商品を追加
+        </button>
+      </div>
+
+      {/* 追加・編集フォーム */}
+      {showForm && (
+        <form
+          onSubmit={handleSubmit}
+          className="mb-6 space-y-3 rounded-lg bg-white p-4 shadow-sm"
+        >
+          <h2 className="font-bold">
+            {editingId ? "商品を編集" : "新しい商品を追加"}
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                商品名 *
+              </label>
+              <input
+                required
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                品種 *
+              </label>
+              <input
+                required
+                value={form.variety}
+                onChange={(e) => setForm({ ...form, variety: e.target.value })}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                重量 (g) *
+              </label>
+              <input
+                required
+                type="number"
+                min="1"
+                value={form.weightGrams}
+                onChange={(e) =>
+                  setForm({ ...form, weightGrams: e.target.value })
+                }
+                className="mt-1 w-full rounded border p-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                価格 (円) *
+              </label>
+              <input
+                required
+                type="number"
+                min="1"
+                value={form.priceJpy}
+                onChange={(e) =>
+                  setForm({ ...form, priceJpy: e.target.value })
+                }
+                className="mt-1 w-full rounded border p-2"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              説明
+            </label>
+            <input
+              value={form.description}
+              onChange={(e) =>
+                setForm({ ...form, description: e.target.value })
+              }
+              className="mt-1 w-full rounded border p-2"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.isAvailable}
+              onChange={(e) =>
+                setForm({ ...form, isAvailable: e.target.checked })
+              }
+            />
+            公開する
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded bg-orange-500 px-4 py-2 text-sm font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+            >
+              {submitting
+                ? "保存中..."
+                : editingId
+                  ? "更新する"
+                  : "追加する"}
+            </button>
+            <button
+              type="button"
+              onClick={cancelForm}
+              className="rounded bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
+            >
+              キャンセル
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* 商品一覧 */}
+      {loading ? (
+        <p className="text-gray-500">読み込み中...</p>
+      ) : products.length === 0 ? (
         <p className="text-gray-500">商品はありません</p>
       ) : (
         <div className="space-y-4">
           {products.map((product) => (
             <div
               key={product.id}
-              className="flex items-center justify-between rounded-lg bg-white p-4 shadow-sm"
+              className="rounded-lg bg-white p-4 shadow-sm"
             >
-              <div>
-                <p className="font-bold">{product.name}</p>
-                <p className="text-sm text-gray-500">
-                  {product.variety} / {product.weightGrams}g /
-                  ¥{product.priceJpy.toLocaleString()}
-                </p>
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <p className="font-bold">{product.name}</p>
+                  <p className="text-sm text-gray-500">
+                    {product.variety} / {product.weightGrams}g /
+                    ¥{product.priceJpy.toLocaleString()}
+                  </p>
+                  {product.description && (
+                    <p className="mt-1 text-sm text-gray-400">
+                      {product.description}
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() =>
+                    toggleAvailability(product.id, product.isAvailable)
+                  }
+                  className={`rounded px-3 py-1 text-xs font-medium ${
+                    product.isAvailable
+                      ? "bg-green-100 text-green-800"
+                      : "bg-gray-100 text-gray-600"
+                  }`}
+                >
+                  {product.isAvailable ? "販売中" : "非公開"}
+                </button>
               </div>
-              <button
-                onClick={() =>
-                  toggleAvailability(product.id, product.isAvailable)
-                }
-                className={`rounded px-4 py-1 text-sm font-medium ${
-                  product.isAvailable
-                    ? "bg-green-100 text-green-800"
-                    : "bg-gray-100 text-gray-600"
-                }`}
-              >
-                {product.isAvailable ? "販売中" : "非公開"}
-              </button>
+              <div className="mt-3 flex gap-2">
+                <button
+                  onClick={() => openEditForm(product)}
+                  className="rounded bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100"
+                >
+                  編集
+                </button>
+                <button
+                  onClick={() => handleDelete(product.id)}
+                  className="rounded bg-red-50 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-100"
+                >
+                  削除
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -3,12 +3,16 @@ import { db } from "@/db";
 import { products } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const allProducts = await db
-      .select()
-      .from(products)
-      .where(eq(products.isAvailable, true));
+    const includeAll = request.nextUrl.searchParams.get("all") === "true";
+
+    const allProducts = includeAll
+      ? await db.select().from(products)
+      : await db
+          .select()
+          .from(products)
+          .where(eq(products.isAvailable, true));
     return NextResponse.json(allProducts);
   } catch (e) {
     console.error("Failed to fetch products:", e);
@@ -19,15 +23,81 @@ export async function GET() {
   }
 }
 
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, variety, weightGrams, priceJpy, description, isAvailable } =
+      body;
+
+    if (!name || !variety || !weightGrams || !priceJpy) {
+      return NextResponse.json(
+        { error: "必須項目が入力されていません" },
+        { status: 400 }
+      );
+    }
+
+    const [product] = await db
+      .insert(products)
+      .values({
+        name,
+        variety,
+        weightGrams,
+        priceJpy,
+        description: description || null,
+        isAvailable: isAvailable ?? true,
+      })
+      .returning();
+
+    return NextResponse.json(product, { status: 201 });
+  } catch (e) {
+    console.error("Failed to create product:", e);
+    return NextResponse.json(
+      { error: "商品の作成に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
 export async function PATCH(request: NextRequest) {
   try {
-    const { id, isAvailable } = await request.json();
-    await db.update(products).set({ isAvailable }).where(eq(products.id, id));
+    const body = await request.json();
+    const { id, ...updates } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "商品IDが必要です" },
+        { status: 400 }
+      );
+    }
+
+    await db.update(products).set(updates).where(eq(products.id, id));
     return NextResponse.json({ success: true });
   } catch (e) {
     console.error("Failed to update product:", e);
     return NextResponse.json(
       { error: "商品の更新に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { id } = await request.json();
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "商品IDが必要です" },
+        { status: 400 }
+      );
+    }
+
+    await db.delete(products).where(eq(products.id, id));
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    console.error("Failed to delete product:", e);
+    return NextResponse.json(
+      { error: "商品の削除に失敗しました" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- 管理画面から商品の追加・編集・削除が可能に
- 商品名、品種、重量、価格、説明、公開/非公開の切り替えをフォームで操作
- Products APIにPOST（追加）・DELETE（削除）エンドポイントを追加、GETで全商品取得に対応

## Test plan
- [ ] 「商品を追加」ボタンからフォームが表示され、新商品を追加できること
- [ ] 既存商品の「編集」ボタンからフォームにデータが入力された状態で編集できること
- [ ] 「削除」ボタンで確認ダイアログ後に商品が削除されること
- [ ] 公開/非公開の切り替えが正常に動作すること
- [ ] カスタマー側の商品一覧には非公開商品が表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)