### PR TITLE
feat: 管理画面の注文フィルタ・ソート機能を追加

### DIFF
--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { OrderStatusBadge } from "@/components/order-status-badge";
 import type { Order } from "@/types";
 
@@ -13,14 +13,45 @@ const statuses = [
   "cancelled",
 ] as const;
 
+const statusLabels: Record<string, string> = {
+  all: "全件",
+  pending: "受付中",
+  confirmed: "確認済み",
+  preparing: "準備中",
+  shipped: "発送済み",
+  delivered: "配達完了",
+  cancelled: "キャンセル",
+};
+
+type SortOrder = "newest" | "oldest";
+
 export default function AdminOrdersPage() {
   const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
 
   useEffect(() => {
     fetch("/api/orders")
       .then((res) => res.json())
-      .then(setOrders);
+      .then(setOrders)
+      .finally(() => setLoading(false));
   }, []);
+
+  const filteredOrders = useMemo(() => {
+    let result =
+      filterStatus === "all"
+        ? orders
+        : orders.filter((o) => o.status === filterStatus);
+
+    result = [...result].sort((a, b) => {
+      const dateA = new Date(a.createdAt).getTime();
+      const dateB = new Date(b.createdAt).getTime();
+      return sortOrder === "newest" ? dateB - dateA : dateA - dateB;
+    });
+
+    return result;
+  }, [orders, filterStatus, sortOrder]);
 
   async function updateStatus(orderId: string, status: string) {
     await fetch("/api/orders", {
@@ -36,11 +67,51 @@ export default function AdminOrdersPage() {
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold">注文管理</h1>
-      {orders.length === 0 ? (
-        <p className="text-gray-500">注文はありません</p>
+
+      {/* フィルタ・ソート */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap gap-1">
+          {["all", ...statuses].map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilterStatus(s)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+                filterStatus === s
+                  ? "bg-orange-500 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
+            >
+              {statusLabels[s] ?? s}
+            </button>
+          ))}
+        </div>
+        <select
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value as SortOrder)}
+          className="rounded border p-1 text-sm"
+        >
+          <option value="newest">新しい順</option>
+          <option value="oldest">古い順</option>
+        </select>
+      </div>
+
+      {/* 件数表示 */}
+      <p className="mb-3 text-sm text-gray-500">
+        {filteredOrders.length}件の注文
+      </p>
+
+      {/* 注文一覧 */}
+      {loading ? (
+        <p className="text-gray-500">読み込み中...</p>
+      ) : filteredOrders.length === 0 ? (
+        <p className="text-gray-500">
+          {filterStatus === "all"
+            ? "注文はありません"
+            : `${statusLabels[filterStatus]}の注文はありません`}
+        </p>
       ) : (
         <div className="space-y-4">
-          {orders.map((order) => (
+          {filteredOrders.map((order) => (
             <div key={order.id} className="rounded-lg bg-white p-4 shadow-sm">
               <div className="flex items-center justify-between">
                 <div>


### PR DESCRIPTION
## Summary
- ステータス別フィルタリング（全件/受付中/確認済み/準備中/発送済み/配達完了/キャンセル）を追加
- 日付順ソート（新しい順/古い順）を追加
- フィルタ結果の件数表示を追加

## Test plan
- [ ] 各ステータスボタンで注文がフィルタリングされること
- [ ] 「新しい順」「古い順」でソートが切り替わること
- [ ] フィルタとソートの組み合わせが正常に動作すること
- [ ] フィルタ結果が0件の場合に適切なメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)