### PR TITLE
chore: .gitignoreにローカル開発ツール設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ supabase/.temp
 # vercel
 .vercel
 
+# local dev tools
+.mcp.json
+docker-compose.yml
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
## Summary
- `.mcp.json`（MCP設定）と`docker-compose.yml`（ローカルDB用）を`.gitignore`に追加
- Vercelデプロイ準備の一環として、本番に不要なローカル開発ファイルを管理対象外に

🤖 Generated with [Claude Code](https://claude.com/claude-code)