### PR TITLE
fix: コミット漏れの修正（ルーティング・管理画面・LIFF）

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "setup:richmenu": "npx tsx scripts/setup-richmenu.ts"
   },
   "dependencies": {
     "@line/bot-sdk": "^10.6.0",

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,29 +1,35 @@
 import Link from "next/link";
+import { cookies } from "next/headers";
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const isLoggedIn = !!cookieStore.get("admin_session")?.value;
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <nav className="border-b bg-white px-6 py-3">
-        <div className="flex items-center gap-6">
-          <span className="font-bold text-gray-800">管理画面</span>
-          <Link
-            href="/admin/orders"
-            className="text-sm text-gray-600 hover:text-gray-800"
-          >
-            注文管理
-          </Link>
-          <Link
-            href="/admin/products"
-            className="text-sm text-gray-600 hover:text-gray-800"
-          >
-            商品管理
-          </Link>
-        </div>
-      </nav>
+      {isLoggedIn && (
+        <nav className="border-b bg-white px-6 py-3">
+          <div className="flex items-center gap-6">
+            <span className="font-bold text-gray-800">管理画面</span>
+            <Link
+              href="/admin/orders"
+              className="text-sm text-gray-600 hover:text-gray-800"
+            >
+              注文管理
+            </Link>
+            <Link
+              href="/admin/products"
+              className="text-sm text-gray-600 hover:text-gray-800"
+            >
+              商品管理
+            </Link>
+          </div>
+        </nav>
+      )}
       <main className="p-6">{children}</main>
     </div>
   );

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { getAllOrders } from "@/db/queries/orders";
 import { AdminOrdersTable } from "@/components/admin/orders-table";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "注文管理",
 };

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { getAllProducts } from "@/db/queries/products";
 import { AdminProductsManager } from "@/components/admin/products-manager";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "商品管理",
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,5 @@
-import Link from "next/link";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-orange-50">
-      <main className="flex flex-col items-center gap-8 p-8 text-center">
-        <h1 className="text-4xl font-bold text-orange-600">みかん農園</h1>
-        <p className="text-lg text-gray-600">
-          新鮮なみかんをお届けします
-        </p>
-        <div className="flex flex-col gap-4">
-          <Link
-            href="/products"
-            className="rounded-full bg-orange-500 px-8 py-3 text-lg font-medium text-white hover:bg-orange-600"
-          >
-            商品を見る
-          </Link>
-          <Link
-            href="/admin/orders"
-            className="text-sm text-gray-500 underline hover:text-gray-700"
-          >
-            管理画面
-          </Link>
-        </div>
-      </main>
-    </div>
-  );
+  redirect("/products");
 }

--- a/src/lib/liff.ts
+++ b/src/lib/liff.ts
@@ -4,9 +4,6 @@ const liffId = process.env.NEXT_PUBLIC_LIFF_ID!;
 
 export async function initLiff() {
   await liff.init({ liffId });
-  if (!liff.isLoggedIn() && !liff.isInClient()) {
-    liff.login({ redirectUri: window.location.href });
-  }
   return liff;
 }
 


### PR DESCRIPTION
## Summary
- `/` が `/products` にリダイレクトしない問題を修正
- 管理画面ページに `force-dynamic` が欠落していた問題を修正
- 管理画面レイアウトのログイン判定ナビ表示を修正
- LIFF外ブラウザアクセス時の不要なLINEログインリダイレクトを除去

## Test plan
- [ ] `/` にアクセスすると `/products` にリダイレクトされること
- [ ] `/admin/orders` が動的にDBからデータ取得すること
- [ ] LIFF外ブラウザでもページが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)