### PR TITLE
fix: LIFFリッチメニューからカート・注文履歴への遷移修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,32 @@
 import { redirect } from "next/navigation";
 
-export default function Home() {
+const ALLOWED_PATHS = [
+  "/products",
+  "/cart",
+  "/orders",
+  "/address",
+  "/confirm",
+  "/complete",
+];
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const liffState = params["liff.state"];
+
+  if (typeof liffState === "string" && liffState.startsWith("/")) {
+    const path = decodeURIComponent(liffState);
+    if (
+      ALLOWED_PATHS.some(
+        (allowed) => path === allowed || path.startsWith(allowed + "/")
+      )
+    ) {
+      redirect(path);
+    }
+  }
+
   redirect("/products");
 }


### PR DESCRIPTION
## Summary
- LIFFリッチメニューの「カート」「注文履歴」ボタンが常に商品一覧(`/products`)に遷移していた問題を修正
- ルートページで `liff.state` クエリパラメータを読み取り、指定パスにリダイレクトするよう変更
- オープンリダイレクト防止のため許可パスのホワイトリストで検証

## Test plan
- [ ] リッチメニュー「カート」→ `/cart` に遷移することを確認
- [ ] リッチメニュー「注文履歴」→ `/orders` に遷移することを確認
- [ ] リッチメニュー「商品を見る」→ `/products` に遷移することを確認
- [ ] 直接 `/` にアクセス → 従来通り `/products` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)