### PR TITLE
feat: 銀行振込注文確定時にLINE通知を送信

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -4,6 +4,7 @@ import { orders, orderItems, addresses } from "@/db/schema";
 import { createOrderSchema } from "@/lib/validations";
 import { getAllOrders, getOrdersByLineUserId } from "@/db/queries/orders";
 import { upsertUser } from "@/db/queries/users";
+import { sendOrderConfirmationWithBankTransfer } from "@/lib/line";
 
 export async function GET(request: NextRequest) {
   try {
@@ -85,6 +86,18 @@ export async function POST(request: NextRequest) {
         unitPriceJpy: item.priceJpy,
       }))
     );
+
+    if (orderData.fulfillmentMethod === "delivery") {
+      try {
+        await sendOrderConfirmationWithBankTransfer(
+          lineUserId,
+          order.id,
+          totalJpy
+        );
+      } catch (err) {
+        console.error("Failed to send LINE notification:", err);
+      }
+    }
 
     return NextResponse.json(order, { status: 201 });
   } catch (e) {

--- a/src/lib/line.ts
+++ b/src/lib/line.ts
@@ -48,4 +48,35 @@ export async function sendPickupReadyNotification({
   });
 }
 
+export async function sendOrderConfirmationWithBankTransfer(
+  lineUserId: string,
+  orderId: string,
+  totalJpy: number
+) {
+  await client.pushMessage({
+    to: lineUserId,
+    messages: [
+      {
+        type: "text",
+        text: [
+          "🍊 ご注文ありがとうございます！",
+          "",
+          `注文ID: ${orderId}`,
+          `合計金額: ¥${totalJpy.toLocaleString()}`,
+          "",
+          "━━━ お振込先 ━━━",
+          "銀行名: ○○銀行",
+          "支店名: △△支店",
+          "口座種別: 普通",
+          "口座番号: 1234567",
+          "口座名義: ミカンノウエン",
+          "━━━━━━━━━━━━",
+          "",
+          "※ご入金確認後、準備を開始いたします。",
+        ].join("\n"),
+      },
+    ],
+  });
+}
+
 export { client as lineClient };


### PR DESCRIPTION
## Summary
- お届け注文（銀行振込）の確定時に、LINE Pushメッセージで振込先情報を通知
- `sendOrderConfirmationWithBankTransfer` 関数を `src/lib/line.ts` に追加
- 注文API（POST `/api/orders`）で `fulfillmentMethod === "delivery"` の場合に通知送信

## Test plan
- [ ] お届け注文を作成し、LINEに振込先通知が届くことを確認
- [ ] 取り置き注文では通知が送信されないことを確認
- [ ] LINE通知失敗時もエラーにならず注文は正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)