### PR TITLE
feat: 受取方法選択画面に支払い方法の案内を追加

### DIFF
--- a/src/app/(customer)/address/page.tsx
+++ b/src/app/(customer)/address/page.tsx
@@ -111,6 +111,15 @@ export default function AddressPage() {
         </button>
       </div>
 
+      {/* 支払い方法の案内 */}
+      <div className="mb-4 rounded-lg bg-white p-3 text-sm text-gray-600 shadow-sm">
+        {method === "pickup" ? (
+          <p>お支払い: <span className="font-medium text-gray-900">受け取り時に現金でお支払い</span></p>
+        ) : (
+          <p>お支払い: <span className="font-medium text-gray-900">銀行振込</span></p>
+        )}
+      </div>
+
       {/* 取り置きフォーム */}
       {method === "pickup" && (
         <div className="space-y-4">

--- a/src/app/(customer)/confirm/page.tsx
+++ b/src/app/(customer)/confirm/page.tsx
@@ -135,7 +135,7 @@ export default function ConfirmPage() {
               <p>
                 時間帯: {TIME_SLOT_LABELS[fulfillment.pickupTimeSlot]}
               </p>
-              <p>お支払い: 店頭でお支払い</p>
+              <p>お支払い: 受け取り時に現金でお支払い</p>
             </div>
           ) : (
             <div className="space-y-1 text-sm text-gray-700">
@@ -148,7 +148,7 @@ export default function ConfirmPage() {
                 {fulfillment.address.line1}
               </p>
               {fulfillment.address.line2 && <p>{fulfillment.address.line2}</p>}
-              <p>お支払い: 銀行振込（事前入金）</p>
+              <p>お支払い: 銀行振込</p>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- 受取方法選択画面（/address）で、選択中の方法に応じた支払い方法を表示
  - 取り置き → 「受け取り時に現金でお支払い」
  - お届け → 「銀行振込」
- 確認画面（/confirm）の支払い方法の文言も統一

## 変更ファイル
- `src/app/(customer)/address/page.tsx` — 支払い方法の案内ブロックを追加
- `src/app/(customer)/confirm/page.tsx` — 文言を統一

## Test plan
- [ ] 受取方法選択画面で「取り置き」選択時に「受け取り時に現金でお支払い」が表示される
- [ ] 受取方法選択画面で「お届け」選択時に「銀行振込」が表示される
- [ ] 確認画面でも同じ文言が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)