### PR TITLE
feat: 注文確定LINE通知の改善

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -4,7 +4,11 @@ import { orders, orderItems, addresses } from "@/db/schema";
 import { createOrderSchema } from "@/lib/validations";
 import { getAllOrders, getOrdersByLineUserId } from "@/db/queries/orders";
 import { upsertUser } from "@/db/queries/users";
-import { sendOrderConfirmationWithBankTransfer } from "@/lib/line";
+import {
+  sendOrderConfirmationWithBankTransfer,
+  sendOrderConfirmationWithPickup,
+} from "@/lib/line";
+import { formatPickupDate, TIME_SLOT_LABELS } from "@/lib/constants";
 
 export async function GET(request: NextRequest) {
   try {
@@ -87,16 +91,22 @@ export async function POST(request: NextRequest) {
       }))
     );
 
-    if (orderData.fulfillmentMethod === "delivery") {
-      try {
-        await sendOrderConfirmationWithBankTransfer(
+    try {
+      if (orderData.fulfillmentMethod === "delivery") {
+        await sendOrderConfirmationWithBankTransfer(lineUserId, totalJpy);
+      } else if (orderData.fulfillmentMethod === "pickup") {
+        const pickupDate = formatPickupDate(orderData.pickupDate);
+        const pickupTimeSlot =
+          TIME_SLOT_LABELS[orderData.pickupTimeSlot] ??
+          orderData.pickupTimeSlot;
+        await sendOrderConfirmationWithPickup({
           lineUserId,
-          order.id,
-          totalJpy
-        );
-      } catch (err) {
-        console.error("Failed to send LINE notification:", err);
+          pickupDate,
+          pickupTimeSlot,
+        });
       }
+    } catch (err) {
+      console.error("Failed to send LINE notification:", err);
     }
 
     return NextResponse.json(order, { status: 201 });

--- a/src/lib/line.ts
+++ b/src/lib/line.ts
@@ -50,7 +50,6 @@ export async function sendPickupReadyNotification({
 
 export async function sendOrderConfirmationWithBankTransfer(
   lineUserId: string,
-  orderId: string,
   totalJpy: number
 ) {
   await client.pushMessage({
@@ -61,7 +60,6 @@ export async function sendOrderConfirmationWithBankTransfer(
         text: [
           "🍊 ご注文ありがとうございます！",
           "",
-          `注文ID: ${orderId}`,
           `合計金額: ¥${totalJpy.toLocaleString()}`,
           "",
           "━━━ お振込先 ━━━",
@@ -73,6 +71,35 @@ export async function sendOrderConfirmationWithBankTransfer(
           "━━━━━━━━━━━━",
           "",
           "※ご入金確認後、準備を開始いたします。",
+        ].join("\n"),
+      },
+    ],
+  });
+}
+
+type OrderConfirmationWithPickupParams = {
+  lineUserId: string;
+  pickupDate: string;
+  pickupTimeSlot: string;
+};
+
+export async function sendOrderConfirmationWithPickup({
+  lineUserId,
+  pickupDate,
+  pickupTimeSlot,
+}: OrderConfirmationWithPickupParams) {
+  await client.pushMessage({
+    to: lineUserId,
+    messages: [
+      {
+        type: "text",
+        text: [
+          "🍊 ご注文ありがとうございます！",
+          "",
+          `【受取日】${pickupDate}`,
+          `【受取時間】${pickupTimeSlot}`,
+          "",
+          "店頭にてお支払いください。",
         ].join("\n"),
       },
     ],


### PR DESCRIPTION
## Summary
- 銀行振込: 顧客に不要な注文IDを通知から削除し、合計金額と振込先のみに簡素化
- 店頭受取: 注文確定時に受取日・時間帯・支払い案内のLINE通知を新規追加

## 変更ファイル
- `src/lib/line.ts` - 銀行振込通知からorderId削除、店頭受取通知関数を追加
- `src/app/api/orders/route.ts` - 店頭受取時もLINE通知を送信するよう分岐追加

## Test plan
- [ ] 銀行振込で注文 → LINE通知に注文IDが含まれないこと
- [ ] 店頭受取で注文 → LINE通知に受取日・時間帯が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)