### PR TITLE
chore: scriptsをtscコンパイル対象から除外

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
## Summary
- `tsconfig.json` の `exclude` に `scripts` ディレクトリを追加
- Vercelビルド時の型エラー（scripts/setup-richmenu.ts）を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)