### PR TITLE
fix: 商品編集時に在庫値が上書きされるバグを修正

### DIFF
--- a/src/components/admin/products-manager.tsx
+++ b/src/components/admin/products-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useState } from "react";
+import { useState } from "react";
 import { productSchema } from "@/lib/validations";
 import {
   createProductAction,
@@ -43,28 +43,36 @@ export function AdminProductsManager({
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<ProductForm>(emptyForm);
+  const [originalStock, setOriginalStock] = useState<{
+    stock: string;
+    stockUnit: string;
+  } | null>(null);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [submitting, setSubmitting] = useState(false);
 
   function openAddForm() {
     setEditingId(null);
     setForm(emptyForm);
+    setOriginalStock(null);
     setErrors({});
     setShowForm(true);
   }
 
   function openEditForm(product: Product) {
     setEditingId(product.id);
+    const stockStr = String(product.stock);
+    const stockUnitStr = product.stockUnit;
     setForm({
       name: product.name,
       variety: product.variety,
       weightGrams: String(product.weightGrams),
       priceJpy: String(product.priceJpy),
       description: product.description ?? "",
-      stock: String(product.stock),
-      stockUnit: product.stockUnit,
+      stock: stockStr,
+      stockUnit: stockUnitStr,
       isAvailable: product.isAvailable,
     });
+    setOriginalStock({ stock: stockStr, stockUnit: stockUnitStr });
     setErrors({});
     setShowForm(true);
   }
@@ -73,6 +81,7 @@ export function AdminProductsManager({
     setShowForm(false);
     setEditingId(null);
     setForm(emptyForm);
+    setOriginalStock(null);
     setErrors({});
   }
 
@@ -105,10 +114,31 @@ export function AdminProductsManager({
     setSubmitting(true);
     setErrors({});
 
-    const payload = {
+    type ProductPayload = Partial<{
+      name: string;
+      variety: string;
+      weightGrams: number;
+      priceJpy: number;
+      description: string | null;
+      stock: number;
+      stockUnit: string;
+      isAvailable: boolean;
+    }>;
+    const payload: ProductPayload = {
       ...parsed.data,
       description: parsed.data.description || null,
     };
+
+    // 編集時: stock/stockUnit が変更されていなければ payload から除外
+    // （注文による在庫減算を上書きしないため）
+    if (editingId && originalStock) {
+      if (form.stock === originalStock.stock) {
+        delete payload.stock;
+      }
+      if (form.stockUnit === originalStock.stockUnit) {
+        delete payload.stockUnit;
+      }
+    }
 
     try {
       if (editingId) {
@@ -122,7 +152,7 @@ export function AdminProductsManager({
           cancelForm();
         }
       } else {
-        const result = await createProductAction(payload);
+        const result = await createProductAction(payload as Parameters<typeof createProductAction>[0]);
         if (result.success && result.product) {
           setProducts((prev) => [...prev, result.product!]);
           cancelForm();


### PR DESCRIPTION
## Summary

- 商品編集フォームで価格・説明文などを変更して保存すると、在庫数（stock）も常に送信されていた
- 注文で減った在庫が、管理者の商品編集時にフォーム表示時の古い値で上書きされてしまっていた
- 編集時に stock/stockUnit がフォーム表示時から変更されていなければ payload から除外するよう修正

## 変更内容

- `originalStock` ステートを追加し、編集フォーム表示時の在庫値を記録
- `handleSubmit` で在庫値が未変更の場合は `delete payload.stock` で除外
- 新規作成時は従来通り全フィールドを送信

## Test plan

- [ ] 管理画面で商品の価格や説明文だけ変更して保存 → 在庫値が変わらないことを確認
- [ ] 管理画面で在庫数を明示的に変更して保存 → 在庫値が更新されることを確認
- [ ] 新規商品作成時に在庫数が正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)