### PR TITLE
refactor: complete/page.tsxをServer Component化

### DIFF
--- a/src/app/(customer)/complete/page.tsx
+++ b/src/app/(customer)/complete/page.tsx
@@ -1,11 +1,16 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
+import type { Metadata } from "next";
 import Link from "next/link";
 
-export default function CompletePage() {
-  const searchParams = useSearchParams();
-  const method = searchParams.get("method");
+export const metadata: Metadata = {
+  title: "注文完了",
+};
+
+export default async function CompletePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ method?: string }>;
+}) {
+  const { method } = await searchParams;
   const isPickup = method === "pickup";
   const isDelivery = method === "delivery";
 


### PR DESCRIPTION
## Summary
- `complete/page.tsx`から`"use client"`を削除しServer Component化
- `useSearchParams()` → async `searchParams` propに置き換え
- `export const metadata`を追加

## Background
Next.js App RouterではServer Componentがデフォルト。`products/page.tsx`の既存パターン（SC → CC子コンポーネント）に統一する段階移行の第1弾。

## Test plan
- [ ] `/complete?method=pickup` でLINEお知らせメッセージが表示される
- [ ] `/complete?method=delivery` で振込案内メッセージが表示される
- [ ] `/complete`（パラメータなし）で注文履歴案内メッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)