### PR TITLE
refactor: admin/login/page.tsxをServer Component化

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,65 +1,10 @@
-"use client";
+import type { Metadata } from "next";
+import { LoginForm } from "@/components/admin/login-form";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+export const metadata: Metadata = {
+  title: "管理画面ログイン",
+};
 
 export default function AdminLoginPage() {
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
-  const router = useRouter();
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setLoading(true);
-
-    try {
-      const res = await fetch("/api/admin/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password }),
-      });
-
-      if (res.ok) {
-        router.push("/admin/orders");
-      } else {
-        const data = await res.json();
-        setError(data.error || "ログインに失敗しました");
-      }
-    } catch {
-      setError("通信エラーが発生しました");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <form
-        onSubmit={handleSubmit}
-        className="w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow"
-      >
-        <h1 className="text-xl font-bold">管理画面ログイン</h1>
-        {error && (
-          <p className="text-sm text-red-600">{error}</p>
-        )}
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="パスワード"
-          className="w-full rounded border p-2"
-          disabled={loading}
-        />
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded bg-gray-800 py-2 text-white hover:bg-gray-900 disabled:opacity-50"
-        >
-          {loading ? "ログイン中..." : "ログイン"}
-        </button>
-      </form>
-    </div>
-  );
+  return <LoginForm />;
 }

--- a/src/components/admin/login-form.tsx
+++ b/src/components/admin/login-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function LoginForm() {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/admin/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+
+      if (res.ok) {
+        router.push("/admin/orders");
+      } else {
+        const data = await res.json();
+        setError(data.error || "ログインに失敗しました");
+      }
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow"
+      >
+        <h1 className="text-xl font-bold">管理画面ログイン</h1>
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="パスワード"
+          className="w-full rounded border p-2"
+          disabled={loading}
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded bg-gray-800 py-2 text-white hover:bg-gray-900 disabled:opacity-50"
+        >
+          {loading ? "ログイン中..." : "ログイン"}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `LoginForm`クライアントコンポーネントを`src/components/admin/login-form.tsx`に分離
- `admin/login/page.tsx`から`"use client"`を削除しServer Component化
- `export const metadata`を追加

## Background
Next.js App RouterではServer Componentがデフォルト。`products/page.tsx`の既存パターン（SC → CC子コンポーネント）に統一する段階移行の第2弾。

## Test plan
- [ ] 管理画面ログインページが表示される
- [ ] 正しいパスワードでログイン成功→`/admin/orders`へ遷移
- [ ] 誤ったパスワードでエラーメッセージ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)