### PR TITLE
refactor: cart/page.tsxをServer Component化

### DIFF
--- a/src/app/(customer)/cart/page.tsx
+++ b/src/app/(customer)/cart/page.tsx
@@ -1,86 +1,10 @@
-"use client";
+import type { Metadata } from "next";
+import { CartContent } from "@/components/cart-content";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { CartItem } from "@/components/cart-item";
-import type { CartItemType } from "@/types";
+export const metadata: Metadata = {
+  title: "カート",
+};
 
 export default function CartPage() {
-  const [cart, setCart] = useState<CartItemType[]>([]);
-
-  useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem("cart") ?? "[]");
-    setCart(stored);
-  }, []);
-
-  function updateCart(newCart: CartItemType[]) {
-    setCart(newCart);
-    localStorage.setItem("cart", JSON.stringify(newCart));
-    window.dispatchEvent(new Event("cart-updated"));
-  }
-
-  function handleUpdateQuantity(id: string, quantity: number) {
-    if (quantity < 1) return;
-    updateCart(
-      cart.map((item) => (item.id === id ? { ...item, quantity } : item))
-    );
-  }
-
-  function handleRemove(id: string) {
-    updateCart(cart.filter((item) => item.id !== id));
-  }
-
-  const total = cart.reduce(
-    (sum, item) => sum + item.priceJpy * item.quantity,
-    0
-  );
-
-  return (
-    <div className="min-h-screen bg-orange-50 p-4">
-      <h1 className="mb-6 text-2xl font-bold text-orange-600">カート</h1>
-      {cart.length === 0 ? (
-        <div className="text-center">
-          <p className="text-gray-700">カートは空です</p>
-          <Link
-            href="/products"
-            className="mt-4 inline-block text-orange-500 underline"
-          >
-            商品一覧に戻る
-          </Link>
-        </div>
-      ) : (
-        <div>
-          <div className="rounded-lg bg-white p-4 shadow-sm">
-            {cart.map((item) => (
-              <CartItem
-                key={item.id}
-                {...item}
-                onUpdateQuantity={handleUpdateQuantity}
-                onRemove={handleRemove}
-              />
-            ))}
-            <div className="mt-4 flex items-center justify-between border-t pt-4">
-              <span className="text-lg font-bold text-gray-900">
-                合計: ¥{total.toLocaleString()}
-              </span>
-              <Link
-                href="/address"
-                className="rounded-full bg-orange-500 px-6 py-2 text-white hover:bg-orange-600"
-              >
-                注文へ進む
-              </Link>
-            </div>
-          </div>
-          <div className="mt-4 text-center">
-            <Link
-              href="/products"
-              className="text-orange-500 underline"
-            >
-              買い物を続ける
-            </Link>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+  return <CartContent />;
 }

--- a/src/components/cart-content.tsx
+++ b/src/components/cart-content.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { CartItem } from "@/components/cart-item";
+import type { CartItemType } from "@/types";
+
+export function CartContent() {
+  const [cart, setCart] = useState<CartItemType[]>([]);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("cart") ?? "[]");
+    setCart(stored);
+  }, []);
+
+  function updateCart(newCart: CartItemType[]) {
+    setCart(newCart);
+    localStorage.setItem("cart", JSON.stringify(newCart));
+    window.dispatchEvent(new Event("cart-updated"));
+  }
+
+  function handleUpdateQuantity(id: string, quantity: number) {
+    if (quantity < 1) return;
+    updateCart(
+      cart.map((item) => (item.id === id ? { ...item, quantity } : item))
+    );
+  }
+
+  function handleRemove(id: string) {
+    updateCart(cart.filter((item) => item.id !== id));
+  }
+
+  const total = cart.reduce(
+    (sum, item) => sum + item.priceJpy * item.quantity,
+    0
+  );
+
+  return (
+    <div className="min-h-screen bg-orange-50 p-4">
+      <h1 className="mb-6 text-2xl font-bold text-orange-600">カート</h1>
+      {cart.length === 0 ? (
+        <div className="text-center">
+          <p className="text-gray-700">カートは空です</p>
+          <Link
+            href="/products"
+            className="mt-4 inline-block text-orange-500 underline"
+          >
+            商品一覧に戻る
+          </Link>
+        </div>
+      ) : (
+        <div>
+          <div className="rounded-lg bg-white p-4 shadow-sm">
+            {cart.map((item) => (
+              <CartItem
+                key={item.id}
+                {...item}
+                onUpdateQuantity={handleUpdateQuantity}
+                onRemove={handleRemove}
+              />
+            ))}
+            <div className="mt-4 flex items-center justify-between border-t pt-4">
+              <span className="text-lg font-bold text-gray-900">
+                合計: ¥{total.toLocaleString()}
+              </span>
+              <Link
+                href="/address"
+                className="rounded-full bg-orange-500 px-6 py-2 text-white hover:bg-orange-600"
+              >
+                注文へ進む
+              </Link>
+            </div>
+          </div>
+          <div className="mt-4 text-center">
+            <Link
+              href="/products"
+              className="text-orange-500 underline"
+            >
+              買い物を続ける
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `CartContent`クライアントコンポーネントを`src/components/cart-content.tsx`に分離
- `cart/page.tsx`から`"use client"`を削除しServer Component化
- `export const metadata`を追加

## Background
Next.js App RouterではServer Componentがデフォルト。`products/page.tsx`の既存パターン（SC → CC子コンポーネント）に統一する段階移行の第3弾。

## Test plan
- [ ] カートページが正しく表示される
- [ ] 商品の数量変更が動作する
- [ ] 商品の削除が動作する
- [ ] ヘッダーのカートバッジが更新される
- [ ] 空カート時のメッセージ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)