### PR TITLE
refactor: お届けフォームをConform + Zodバリデーションに移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "setup:richmenu": "npx tsx scripts/setup-richmenu.ts"
   },
   "dependencies": {
+    "@conform-to/react": "^1.17.1",
+    "@conform-to/zod": "^1.17.1",
     "@line/bot-sdk": "^10.6.0",
     "@line/liff": "^2.27.3",
     "drizzle-orm": "^0.45.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@conform-to/react':
+        specifier: ^1.17.1
+        version: 1.17.1(react@19.2.3)
+      '@conform-to/zod':
+        specifier: ^1.17.1
+        version: 1.17.1(zod@4.3.6)
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0
@@ -136,6 +142,19 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@conform-to/dom@1.17.1':
+    resolution: {integrity: sha512-vpwCodVVWpQ6kbrlu5F85BC99ozDxqcrhmt+YDD81bCwvt6NtiycFID3NQQGQyn+bzmpb4qlF3Ay9YcljnrNHw==}
+
+  '@conform-to/react@1.17.1':
+    resolution: {integrity: sha512-AXj6HMiG0e6mJXzVNDmeQ9FH4LbGA4HdSt+a0Yb09kEnpESkK3zCopFb8RkO8kls4XMQO05KAmaE6KDlhSzprQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@conform-to/zod@1.17.1':
+    resolution: {integrity: sha512-oFt2OdCrAhNEKjjyc8QAgiykDI9s+RG9nAuxrqGyp/BFXuRPPiu0e+QIVUAxSnWtZ82swtSaf87DI+jTAyhaLg==}
+    peerDependencies:
+      zod: ^3.21.0 || ^4.0.0
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -2784,6 +2803,18 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@conform-to/dom@1.17.1': {}
+
+  '@conform-to/react@1.17.1(react@19.2.3)':
+    dependencies:
+      '@conform-to/dom': 1.17.1
+      react: 19.2.3
+
+  '@conform-to/zod@1.17.1(zod@4.3.6)':
+    dependencies:
+      '@conform-to/dom': 1.17.1
+      zod: 4.3.6
 
   '@drizzle-team/brocli@0.10.2': {}
 

--- a/src/components/address-form.tsx
+++ b/src/components/address-form.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useLiff } from "@/components/liff-provider";
+import { DeliveryAddressFields } from "@/components/delivery-address-fields";
 import { TIME_SLOT_OPTIONS, getPickupDateOptions } from "@/lib/constants";
+import type { AddressFormData } from "@/lib/validations";
 import type { FulfillmentMethod, PickupTimeSlot } from "@/types";
 
 export function AddressForm() {
@@ -13,7 +15,7 @@ export function AddressForm() {
   const [pickupDate, setPickupDate] = useState("");
   const [pickupTimeSlot, setPickupTimeSlot] = useState<PickupTimeSlot | "">("");
   const pickupDateOptions = getPickupDateOptions();
-  const [addressForm, setAddressForm] = useState({
+  const [savedAddress, setSavedAddress] = useState<AddressFormData>({
     recipientName: "",
     postalCode: "",
     prefecture: "",
@@ -38,7 +40,7 @@ export function AddressForm() {
         const data = await res.json();
         if (data.length > 0) {
           const latest = data[0];
-          setAddressForm({
+          setSavedAddress({
             recipientName: latest.recipientName ?? "",
             postalCode: latest.postalCode ?? "",
             prefecture: latest.prefecture ?? "",
@@ -56,29 +58,17 @@ export function AddressForm() {
     fetchSavedAddress();
   }, [profile]);
 
-  function handleAddressChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setAddressForm({ ...addressForm, [e.target.name]: e.target.value });
+  const isPickupValid = method === "pickup" && pickupDate !== "" && pickupTimeSlot !== "";
+
+  function handlePickupProceed() {
+    if (!isPickupValid) return;
+    const orderData = { fulfillmentMethod: "pickup" as const, pickupDate, pickupTimeSlot };
+    sessionStorage.setItem("orderFulfillment", JSON.stringify(orderData));
+    router.push("/confirm");
   }
 
-  const isPickupValid = method === "pickup" && pickupDate !== "" && pickupTimeSlot !== "";
-  const isPostalCodeValid = /^\d{3}-?\d{4}$/.test(addressForm.postalCode.trim());
-  const isDeliveryValid =
-    method === "delivery" &&
-    addressForm.recipientName.trim() !== "" &&
-    isPostalCodeValid &&
-    addressForm.prefecture.trim() !== "" &&
-    addressForm.city.trim() !== "" &&
-    addressForm.line1.trim() !== "";
-  const canProceed = isPickupValid || isDeliveryValid;
-
-  function handleProceed() {
-    if (!canProceed) return;
-
-    const orderData =
-      method === "pickup"
-        ? { fulfillmentMethod: "pickup" as const, pickupDate, pickupTimeSlot }
-        : { fulfillmentMethod: "delivery" as const, address: addressForm };
-
+  function handleDeliverySubmit(address: AddressFormData) {
+    const orderData = { fulfillmentMethod: "delivery" as const, address };
     sessionStorage.setItem("orderFulfillment", JSON.stringify(orderData));
     router.push("/confirm");
   }
@@ -181,87 +171,25 @@ export function AddressForm() {
               <div className="h-8 w-8 animate-spin rounded-full border-4 border-orange-300 border-t-orange-600" />
             </div>
           ) : (
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-900">
-                  受取人名
-                </label>
-                <input
-                  name="recipientName"
-                  value={addressForm.recipientName}
-                  onChange={handleAddressChange}
-                  className="mt-1 w-full rounded border p-2"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-900">
-                  郵便番号
-                </label>
-                <input
-                  name="postalCode"
-                  value={addressForm.postalCode}
-                  onChange={handleAddressChange}
-                  placeholder="123-4567"
-                  className="mt-1 w-full rounded border p-2"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-900">
-                  都道府県
-                </label>
-                <input
-                  name="prefecture"
-                  value={addressForm.prefecture}
-                  onChange={handleAddressChange}
-                  className="mt-1 w-full rounded border p-2"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-900">
-                  市区町村
-                </label>
-                <input
-                  name="city"
-                  value={addressForm.city}
-                  onChange={handleAddressChange}
-                  className="mt-1 w-full rounded border p-2"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-900">
-                  番地
-                </label>
-                <input
-                  name="line1"
-                  value={addressForm.line1}
-                  onChange={handleAddressChange}
-                  className="mt-1 w-full rounded border p-2"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-900">
-                  建物名・部屋番号（任意）
-                </label>
-                <input
-                  name="line2"
-                  value={addressForm.line2}
-                  onChange={handleAddressChange}
-                  className="mt-1 w-full rounded border p-2"
-                />
-              </div>
-            </div>
+            <DeliveryAddressFields
+              key={JSON.stringify(savedAddress)}
+              defaultAddress={savedAddress}
+              onValidSubmit={handleDeliverySubmit}
+            />
           )}
         </div>
       )}
 
-      {/* 確認画面へ進むボタン */}
-      <button
-        onClick={handleProceed}
-        disabled={!canProceed}
-        className="mt-6 w-full rounded-full bg-orange-500 py-3 font-medium text-white hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        確認画面へ進む
-      </button>
+      {/* 取り置き: 確認画面へ進むボタン */}
+      {method === "pickup" && (
+        <button
+          onClick={handlePickupProceed}
+          disabled={!isPickupValid}
+          className="mt-6 w-full rounded-full bg-orange-500 py-3 font-medium text-white hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          確認画面へ進む
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/delivery-address-fields.tsx
+++ b/src/components/delivery-address-fields.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useForm, getFormProps, getInputProps } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod/v4";
+import { addressSchema } from "@/lib/validations";
+import type { AddressFormData } from "@/lib/validations";
+
+type Props = {
+  defaultAddress: AddressFormData;
+  onValidSubmit: (data: AddressFormData) => void;
+};
+
+export function DeliveryAddressFields({ defaultAddress, onValidSubmit }: Props) {
+  const [form, fields] = useForm({
+    id: "delivery-address",
+    defaultValue: defaultAddress,
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: addressSchema });
+    },
+    onSubmit(event, { submission }) {
+      event.preventDefault();
+      if (submission?.status === "success" && submission.value) {
+        onValidSubmit(submission.value);
+      }
+    },
+  });
+
+  return (
+    <form {...getFormProps(form)} className="space-y-4">
+      <div>
+        <label htmlFor={fields.recipientName.id} className="block text-sm font-medium text-gray-900">
+          受取人名
+        </label>
+        <input
+          {...getInputProps(fields.recipientName, { type: "text" })}
+          className="mt-1 w-full rounded border p-2"
+        />
+        {fields.recipientName.errors && (
+          <p className="mt-1 text-xs text-red-600">{fields.recipientName.errors[0]}</p>
+        )}
+      </div>
+      <div>
+        <label htmlFor={fields.postalCode.id} className="block text-sm font-medium text-gray-900">
+          郵便番号
+        </label>
+        <input
+          {...getInputProps(fields.postalCode, { type: "text" })}
+          placeholder="123-4567"
+          className="mt-1 w-full rounded border p-2"
+        />
+        {fields.postalCode.errors && (
+          <p className="mt-1 text-xs text-red-600">{fields.postalCode.errors[0]}</p>
+        )}
+      </div>
+      <div>
+        <label htmlFor={fields.prefecture.id} className="block text-sm font-medium text-gray-900">
+          都道府県
+        </label>
+        <input
+          {...getInputProps(fields.prefecture, { type: "text" })}
+          className="mt-1 w-full rounded border p-2"
+        />
+        {fields.prefecture.errors && (
+          <p className="mt-1 text-xs text-red-600">{fields.prefecture.errors[0]}</p>
+        )}
+      </div>
+      <div>
+        <label htmlFor={fields.city.id} className="block text-sm font-medium text-gray-900">
+          市区町村
+        </label>
+        <input
+          {...getInputProps(fields.city, { type: "text" })}
+          className="mt-1 w-full rounded border p-2"
+        />
+        {fields.city.errors && (
+          <p className="mt-1 text-xs text-red-600">{fields.city.errors[0]}</p>
+        )}
+      </div>
+      <div>
+        <label htmlFor={fields.line1.id} className="block text-sm font-medium text-gray-900">
+          番地
+        </label>
+        <input
+          {...getInputProps(fields.line1, { type: "text" })}
+          className="mt-1 w-full rounded border p-2"
+        />
+        {fields.line1.errors && (
+          <p className="mt-1 text-xs text-red-600">{fields.line1.errors[0]}</p>
+        )}
+      </div>
+      <div>
+        <label htmlFor={fields.line2.id} className="block text-sm font-medium text-gray-900">
+          建物名・部屋番号（任意）
+        </label>
+        <input
+          {...getInputProps(fields.line2, { type: "text" })}
+          className="mt-1 w-full rounded border p-2"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="mt-6 w-full rounded-full bg-orange-500 py-3 font-medium text-white hover:bg-orange-600"
+      >
+        確認画面へ進む
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- お届け住所フォームを手動`useState`管理からConform（`@conform-to/react`）に移行
- 既存の`addressSchema`（Zod）をそのままバリデーションに活用
- `DeliveryAddressFields`コンポーネントとして分離し、フィールドごとのエラーメッセージを表示
- 取り置きフォームは変更なし（スコープ限定）

## Changes
- `@conform-to/react`, `@conform-to/zod` を追加
- 新規: `src/components/delivery-address-fields.tsx`
- 変更: `src/components/address-form.tsx`（手動バリデーション除去、Conformコンポーネントに委譲）

## Test plan
- [ ] お届けフォームの各フィールドに入力できる
- [ ] 必須フィールド未入力でsubmit→エラーメッセージが表示される
- [ ] 郵便番号の形式バリデーションが動作する
- [ ] 保存済み住所が自動読み込みされる
- [ ] 正しい入力で確認画面へ遷移する
- [ ] 取り置きフォームが従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)