### PR TITLE
fix: 管理画面バリエーション表示の重複修正

### DIFF
--- a/src/components/admin/products-manager.tsx
+++ b/src/components/admin/products-manager.tsx
@@ -417,8 +417,7 @@ export function AdminProductsManager({
                         className="flex items-center justify-between text-sm"
                       >
                         <span className="text-gray-900">
-                          {v.label} - {v.weightKg}kg -
-                          ¥{v.priceJpy.toLocaleString()}
+                          {v.label} - ¥{v.priceJpy.toLocaleString()}
                           {v.isGiftOnly && " 🎁"}
                           {!v.isAvailable && " (非公開)"}
                         </span>


### PR DESCRIPTION
## Summary
管理画面のバリエーション一覧でlabelとweightKgが重複表示されていた問題を修正。

Before: `1kg - 1kg - ¥300`
After: `1kg - ¥300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)