### PR TITLE
fix: 管理画面ナビにアクティブ状態表示を追加

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { auth } from "@/auth";
 import { LogoutButton } from "@/components/admin/logout-button";
+import { AdminNavLink } from "@/components/admin/admin-nav-link";
 
 export default async function AdminLayout({
   children,
@@ -16,24 +16,9 @@ export default async function AdminLayout({
         <nav className="border-b bg-white px-6 py-3">
           <div className="flex items-center gap-6">
             <span className="font-bold text-gray-900">管理画面</span>
-            <Link
-              href="/admin/orders"
-              className="text-sm text-gray-900 hover:text-black"
-            >
-              注文管理
-            </Link>
-            <Link
-              href="/admin/products"
-              className="text-sm text-gray-900 hover:text-black"
-            >
-              商品管理
-            </Link>
-            <Link
-              href="/admin/legal"
-              className="text-sm text-gray-900 hover:text-black"
-            >
-              特商法表記
-            </Link>
+            <AdminNavLink href="/admin/orders">注文管理</AdminNavLink>
+            <AdminNavLink href="/admin/products">商品管理</AdminNavLink>
+            <AdminNavLink href="/admin/legal">特商法表記</AdminNavLink>
             <div className="ml-auto">
               <LogoutButton />
             </div>

--- a/src/components/admin/admin-nav-link.tsx
+++ b/src/components/admin/admin-nav-link.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export function AdminNavLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isActive = pathname.startsWith(href);
+
+  return (
+    <Link
+      href={href}
+      className={`text-sm font-medium ${
+        isActive
+          ? "text-orange-600 underline underline-offset-4"
+          : "text-gray-500 hover:text-gray-900"
+      }`}
+    >
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- 管理画面ヘッダーで現在どのページにいるかわからない問題を修正
- `AdminNavLink` クライアントコンポーネントを新規作成し、`usePathname()` でアクティブ状態を判定
- アクティブリンクはオレンジ色+アンダーラインで強調、非アクティブはグレーで表示

## Test plan
- [ ] 管理画面の各ページ（注文管理・商品管理・特商法表記）に遷移し、対応するリンクがハイライトされることを確認
- [ ] 非アクティブなリンクがグレー表示であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)