### PR TITLE
feat: 複数Googleアカウントで管理画面ログイン可能にする

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -38,8 +38,11 @@ export const authConfig = {
   callbacks: {
     async signIn({ account, profile }) {
       if (account?.provider === "google") {
-        const adminEmail = process.env.ADMIN_EMAIL;
-        return !!adminEmail && profile?.email === adminEmail;
+        const adminEmails = (process.env.ADMIN_EMAILS ?? process.env.ADMIN_EMAIL ?? "")
+          .split(",")
+          .map((e) => e.trim())
+          .filter(Boolean);
+        return adminEmails.length > 0 && adminEmails.includes(profile?.email ?? "");
       }
       return true;
     },


### PR DESCRIPTION
## Summary
- `ADMIN_EMAILS`環境変数にカンマ区切りで複数メールアドレスを設定可能にした
- 既存の`ADMIN_EMAIL`（単数）にもフォールバック対応
- 本番Vercelに`ADMIN_EMAILS`は設定済み

## Test plan
- [ ] 本番デプロイ後、既存アカウント(mikannokondo@gmail.com)でログインできること
- [ ] 新規追加アカウント(tazuko356@gmail.com)でログインできること
- [ ] 未登録アカウントではログインできないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)