### PR TITLE
fix: 管理画面スマホ対応＋高齢者アクセシビリティ改善

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -13,19 +13,19 @@ export default async function AdminLayout({
   return (
     <div className="min-h-screen bg-gray-50">
       {isAdmin && (
-        <nav className="border-b bg-white px-6 py-4">
-          <div className="flex items-center gap-8">
-            <span className="text-lg font-bold text-gray-900">管理画面</span>
+        <nav className="border-b bg-white px-4 py-3 sm:px-6 sm:py-4">
+          <div className="flex items-center justify-between gap-3">
+            <span className="shrink-0 text-xl font-bold text-gray-900">管理画面</span>
+            <LogoutButton />
+          </div>
+          <div className="-mx-1 mt-2 flex gap-1 overflow-x-auto">
             <AdminNavLink href="/admin/orders">注文管理</AdminNavLink>
             <AdminNavLink href="/admin/products">商品管理</AdminNavLink>
             <AdminNavLink href="/admin/legal">特商法表記</AdminNavLink>
-            <div className="ml-auto">
-              <LogoutButton />
-            </div>
           </div>
         </nav>
       )}
-      <main className="p-6">{children}</main>
+      <main className="p-4 sm:p-6">{children}</main>
     </div>
   );
 }

--- a/src/components/admin/admin-nav-link.tsx
+++ b/src/components/admin/admin-nav-link.tsx
@@ -16,10 +16,10 @@ export function AdminNavLink({
   return (
     <Link
       href={href}
-      className={`text-base font-medium ${
+      className={`shrink-0 rounded-md px-2 py-2 text-lg font-medium ${
         isActive
-          ? "text-orange-600 underline underline-offset-4"
-          : "text-gray-700 hover:text-gray-900"
+          ? "bg-orange-50 text-orange-600"
+          : "text-gray-900 hover:bg-gray-100"
       }`}
     >
       {children}

--- a/src/components/admin/google-login-button.tsx
+++ b/src/components/admin/google-login-button.tsx
@@ -16,8 +16,8 @@ function Loading() {
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow">
         <div className="animate-pulse space-y-4">
-          <div className="h-7 w-48 rounded bg-gray-200" />
-          <div className="h-12 rounded bg-gray-200" />
+          <div className="h-8 w-48 rounded bg-gray-200" />
+          <div className="h-14 rounded bg-gray-200" />
         </div>
       </div>
     </div>
@@ -42,17 +42,17 @@ function WebViewGuide() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-sm space-y-5 rounded-lg bg-white p-8 shadow">
-        <h1 className="text-xl font-bold">管理画面ログイン</h1>
+        <h1 className="text-2xl font-bold text-gray-900">管理画面ログイン</h1>
         <div className="rounded-lg bg-amber-50 p-4">
-          <p className="text-base font-medium text-amber-800">
+          <p className="text-lg font-medium text-amber-800">
             LINEアプリ内ではGoogleログインが使えません
           </p>
         </div>
         <div className="space-y-3">
-          <p className="text-base text-gray-700">
+          <p className="text-lg text-gray-900">
             以下の手順でログインしてください:
           </p>
-          <ol className="list-inside list-decimal space-y-2 text-base text-gray-700">
+          <ol className="list-inside list-decimal space-y-2 text-lg text-gray-900">
             <li>下のボタンでURLをコピー</li>
             <li>SafariまたはChromeを開く</li>
             <li>アドレスバーに貼り付けて移動</li>
@@ -60,7 +60,7 @@ function WebViewGuide() {
         </div>
         <button
           onClick={handleCopy}
-          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-blue-600 py-4 text-base font-medium text-white hover:bg-blue-700"
+          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-blue-600 py-4 text-lg font-medium text-white hover:bg-blue-700"
         >
           {copied ? "コピーしました!" : "URLをコピー"}
         </button>
@@ -81,13 +81,13 @@ export function GoogleLoginButton() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm space-y-4 rounded-lg bg-white p-8 shadow">
-        <h1 className="text-xl font-bold">管理画面ログイン</h1>
+      <div className="w-full max-w-sm space-y-5 rounded-lg bg-white p-8 shadow">
+        <h1 className="text-2xl font-bold text-gray-900">管理画面ログイン</h1>
         <button
           onClick={() => signIn("google", { callbackUrl: "/admin/orders" })}
-          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded border border-gray-300 bg-white py-2 text-sm font-medium text-gray-900 hover:bg-gray-50"
+          className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white py-4 text-lg font-medium text-gray-900 hover:bg-gray-50"
         >
-          <svg className="h-5 w-5" viewBox="0 0 24 24">
+          <svg className="h-6 w-6" viewBox="0 0 24 24">
             <path
               d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
               fill="#4285F4"

--- a/src/components/admin/legal-info-editor.tsx
+++ b/src/components/admin/legal-info-editor.tsx
@@ -117,7 +117,7 @@ export function LegalInfoEditor({
 
       {message && (
         <div
-          className={`mb-4 rounded p-3 text-base ${
+          className={`mb-4 rounded p-3 text-lg ${
             message.type === "success"
               ? "bg-green-50 text-green-700"
               : "bg-red-50 text-red-700"
@@ -127,12 +127,12 @@ export function LegalInfoEditor({
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-5">
         {fields.map((field) => (
           <div key={field.key}>
             <label
               htmlFor={field.key}
-              className="mb-1 block text-base font-medium text-gray-800"
+              className="mb-1 block text-lg font-medium text-gray-900"
             >
               {field.label}
               {field.required && (
@@ -147,7 +147,7 @@ export function LegalInfoEditor({
                   setForm((prev) => ({ ...prev, [field.key]: e.target.value }))
                 }
                 rows={3}
-                className="w-full rounded border border-gray-300 px-3 py-2.5 text-base focus:border-blue-500 focus:outline-none"
+                className="w-full rounded border border-gray-300 px-3 py-3 text-lg focus:border-blue-500 focus:outline-none"
                 required={field.required}
               />
             ) : (
@@ -158,7 +158,7 @@ export function LegalInfoEditor({
                 onChange={(e) =>
                   setForm((prev) => ({ ...prev, [field.key]: e.target.value }))
                 }
-                className="w-full rounded border border-gray-300 px-3 py-2.5 text-base focus:border-blue-500 focus:outline-none"
+                className="w-full rounded border border-gray-300 px-3 py-3 text-lg focus:border-blue-500 focus:outline-none"
                 required={field.required}
               />
             )}
@@ -168,7 +168,7 @@ export function LegalInfoEditor({
         <button
           type="submit"
           disabled={submitting}
-          className="cursor-pointer rounded bg-blue-600 px-6 py-2.5 text-base font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="cursor-pointer rounded bg-blue-600 px-6 py-3 text-lg font-medium text-white hover:bg-blue-700 disabled:opacity-50"
         >
           {submitting ? "保存中..." : "保存"}
         </button>

--- a/src/components/admin/logout-button.tsx
+++ b/src/components/admin/logout-button.tsx
@@ -10,7 +10,7 @@ export function LogoutButton() {
     <>
       <button
         onClick={() => setIsOpen(true)}
-        className="cursor-pointer rounded border border-red-300 px-4 py-2 text-base text-red-600 transition-all duration-200 hover:border-red-500 hover:bg-red-600 hover:text-white"
+        className="cursor-pointer rounded border border-red-300 px-5 py-2.5 text-base font-medium text-red-600 transition-all duration-200 hover:border-red-500 hover:bg-red-600 hover:text-white"
       >
         ログアウト
       </button>
@@ -24,19 +24,19 @@ export function LogoutButton() {
             className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <p className="mb-6 text-center text-lg font-bold text-gray-900">
+            <p className="mb-6 text-center text-xl font-bold text-gray-900">
               ログアウトしますか？
             </p>
             <div className="flex gap-3">
               <button
                 onClick={() => setIsOpen(false)}
-                className="flex-1 cursor-pointer rounded border border-gray-300 px-4 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-100"
+                className="flex-1 cursor-pointer rounded border border-gray-300 px-4 py-3.5 text-lg font-medium text-gray-900 transition-colors hover:bg-gray-100"
               >
                 キャンセル
               </button>
               <button
                 onClick={() => signOut({ callbackUrl: "/admin/login" })}
-                className="flex-1 cursor-pointer rounded bg-red-600 px-4 py-3 text-base font-medium text-white transition-colors hover:bg-red-700"
+                className="flex-1 cursor-pointer rounded bg-red-600 px-4 py-3.5 text-lg font-medium text-white transition-colors hover:bg-red-700"
               >
                 ログアウト
               </button>

--- a/src/components/admin/orders-table.tsx
+++ b/src/components/admin/orders-table.tsx
@@ -101,7 +101,7 @@ export function AdminOrdersTable({
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value)}
-          className="rounded border px-3 py-2 text-base text-gray-900"
+          className="rounded border px-4 py-3 text-lg text-gray-900"
         >
           {["all", ...allStatuses].map((s) => (
             <option key={s} value={s}>
@@ -112,7 +112,7 @@ export function AdminOrdersTable({
         <select
           value={sortOrder}
           onChange={(e) => setSortOrder(e.target.value as SortOrder)}
-          className="rounded border px-3 py-2 text-base text-gray-900"
+          className="rounded border px-4 py-3 text-lg text-gray-900"
         >
           <option value="newest">新しい順</option>
           <option value="oldest">古い順</option>
@@ -120,13 +120,13 @@ export function AdminOrdersTable({
       </div>
 
       {/* 件数表示 */}
-      <p className="mb-3 text-base text-gray-900">
+      <p className="mb-3 text-lg font-medium text-gray-900">
         {filteredOrders.length}件の注文
       </p>
 
       {/* 注文一覧 */}
       {filteredOrders.length === 0 ? (
-        <p className="text-gray-900">
+        <p className="text-lg text-gray-900">
           {filterStatus === "all"
             ? "注文はありません"
             : `${statusLabels[filterStatus]}の注文はありません`}
@@ -134,24 +134,24 @@ export function AdminOrdersTable({
       ) : (
         <div className="space-y-4">
           {filteredOrders.map((order) => (
-            <div key={order.id} className="rounded-lg bg-white p-5 shadow-sm">
-              <div className="flex items-center justify-between">
+            <div key={order.id} className="rounded-lg bg-white p-4 shadow-sm sm:p-5">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-base text-gray-900">
+                  <p className="text-lg text-gray-900">
                     {new Date(order.createdAt).toLocaleDateString("ja-JP")}
                   </p>
-                  <p className="text-lg font-bold">
+                  <p className="text-xl font-bold text-gray-900">
                     ¥{order.totalJpy.toLocaleString()}
                   </p>
                   {order.user && (
-                    <p className="text-base text-gray-900">
+                    <p className="text-lg text-gray-900">
                       {order.user.displayName}
                     </p>
                   )}
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2">
                   <span
-                    className={`rounded-full px-3 py-1.5 text-sm font-medium ${
+                    className={`rounded-full px-3 py-2 text-base font-medium ${
                       order.fulfillmentMethod === "pickup"
                         ? "bg-emerald-100 text-emerald-800"
                         : "bg-sky-100 text-sky-800"
@@ -164,9 +164,9 @@ export function AdminOrdersTable({
               </div>
 
               {/* 受取詳細 */}
-              <div className="mt-3 text-base text-gray-900">
+              <div className="mt-3 text-lg text-gray-900">
                 {order.fulfillmentMethod === "pickup" ? (
-                  <div className="space-y-0.5">
+                  <div className="space-y-1">
                     <p>
                       受取日:{" "}
                       {order.pickupDate
@@ -196,7 +196,7 @@ export function AdminOrdersTable({
                 <select
                   value={order.status}
                   onChange={(e) => updateStatus(order.id, e.target.value)}
-                  className="rounded border px-3 py-2 text-base text-gray-900"
+                  className="rounded border px-4 py-3 text-lg text-gray-900"
                 >
                   {getStatusOptions(order.fulfillmentMethod).map((s) => (
                     <option key={s} value={s}>

--- a/src/components/admin/product-card.tsx
+++ b/src/components/admin/product-card.tsx
@@ -197,10 +197,10 @@ export function ProductCard({
   return (
     <div className="rounded-lg bg-white p-5 shadow-sm">
       <div className="flex flex-wrap items-center gap-3">
-        <h2 className="text-lg font-bold text-gray-900">{product.name}</h2>
+        <h2 className="text-xl font-bold text-gray-900">{product.name}</h2>
         <button
           onClick={handleToggleAvailability}
-          className={`cursor-pointer rounded-full px-3 py-1.5 text-sm font-bold ${
+          className={`cursor-pointer rounded-full px-4 py-2 text-base font-bold ${
             product.isAvailable
               ? "bg-green-100 text-green-800"
               : "bg-gray-200 text-gray-700"
@@ -208,7 +208,7 @@ export function ProductCard({
         >
           {product.isAvailable ? "販売中" : "非公開"}
         </button>
-        <span className="text-base font-bold text-gray-700">
+        <span className="text-lg font-bold text-gray-900">
           在庫{" "}
           {product.stockKg === 0 ? (
             <span className="font-medium text-red-600">売り切れ</span>
@@ -218,21 +218,21 @@ export function ProductCard({
             </span>
           )}
         </span>
-        <span className="text-base font-bold text-gray-700">
+        <span className="text-lg font-bold text-gray-900">
           バリエーション <span className="text-gray-900">{product.variants.length}件</span>
         </span>
       </div>
       {product.description && (
-        <p className="mt-3 text-base leading-relaxed text-gray-700">
+        <p className="mt-3 text-lg leading-relaxed text-gray-900">
           {product.description}
         </p>
       )}
 
       {/* バリエーション一覧（展開/折りたたみ） */}
-      <div className="mt-2">
+      <div className="mt-3">
         <button
           onClick={onToggleExpand}
-          className="cursor-pointer text-sm text-orange-600 hover:underline"
+          className="cursor-pointer rounded-md px-3 py-2 text-base font-medium text-orange-600 hover:bg-orange-50"
         >
           {expanded ? "バリエーションを閉じる" : "バリエーションを表示"}
         </button>
@@ -240,30 +240,31 @@ export function ProductCard({
           <div className="mt-2 border-t pt-3">
             {/* Shopify風 Saveバー */}
             {getDirtyVariants().length > 0 && (
-              <div className="mb-3 flex items-center justify-between rounded-lg bg-orange-50 px-4 py-3">
-                <span className="text-base font-medium text-orange-800">
+              <div className="mb-3 flex flex-col gap-2 rounded-lg bg-orange-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <span className="text-lg font-medium text-orange-800">
                   未保存の変更があります
                 </span>
                 <div className="flex gap-2">
                   <button
                     onClick={resetVariantEdits}
-                    className="cursor-pointer rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    className="cursor-pointer rounded border border-gray-300 bg-white px-5 py-2.5 text-base font-medium text-gray-900 hover:bg-gray-50"
                   >
                     元に戻す
                   </button>
                   <button
                     onClick={handleSaveAllVariants}
                     disabled={savingVariants}
-                    className="cursor-pointer rounded bg-orange-500 px-5 py-2 text-sm font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+                    className="cursor-pointer rounded bg-orange-500 px-6 py-2.5 text-base font-medium text-white hover:bg-orange-600 disabled:opacity-50"
                   >
                     {savingVariants ? "保存中..." : "保存"}
                   </button>
                 </div>
               </div>
             )}
-            <table className="w-full border-collapse overflow-hidden rounded-lg border border-gray-200 text-base">
+            <div className="-mx-1 overflow-x-auto px-1">
+            <table className="w-full min-w-[640px] border-collapse overflow-hidden rounded-lg border border-gray-200 text-base">
               <thead>
-                <tr className="bg-gray-100 text-left text-base font-semibold text-gray-800">
+                <tr className="bg-gray-100 text-left text-base font-semibold text-gray-900">
                   <th className="px-4 py-3">ラベル</th>
                   <th className="px-4 py-3">価格</th>
                   <th className="px-4 py-3">区分</th>
@@ -284,38 +285,38 @@ export function ProductCard({
                         <input
                           value={edit.label}
                           onChange={(e) => updateVariantField(v.id, v, "label", e.target.value)}
-                          className={`w-full rounded border bg-transparent px-3 py-2 text-base text-gray-900 focus:bg-white focus:outline-none ${labelDirty ? "border-orange-400 bg-orange-50" : "border-gray-200 focus:border-orange-400"}`}
+                          className={`w-full rounded border bg-transparent px-3 py-2.5 text-base text-gray-900 focus:bg-white focus:outline-none ${labelDirty ? "border-orange-400 bg-orange-50" : "border-gray-200 focus:border-orange-400"}`}
                         />
                       </td>
                       <td className="px-4 py-3">
                         <div className="flex items-center gap-1">
-                          <span className="text-base text-gray-700">¥</span>
+                          <span className="text-base text-gray-900">¥</span>
                           <input
                             type="number"
                             value={edit.priceJpy}
                             onChange={(e) => updateVariantField(v.id, v, "priceJpy", e.target.value)}
-                            className={`w-full rounded border bg-transparent px-3 py-2 text-base text-gray-900 focus:bg-white focus:outline-none ${priceDirty ? "border-orange-400 bg-orange-50" : "border-gray-200 focus:border-orange-400"}`}
+                            className={`w-full rounded border bg-transparent px-3 py-2.5 text-base text-gray-900 focus:bg-white focus:outline-none ${priceDirty ? "border-orange-400 bg-orange-50" : "border-gray-200 focus:border-orange-400"}`}
                           />
                         </div>
                       </td>
                       <td className="px-4 py-3">
-                        <label className={`flex items-center gap-2 rounded px-2 py-1 text-base text-gray-800 ${giftDirty ? "bg-orange-50 ring-1 ring-orange-400" : ""}`}>
+                        <label className={`flex items-center gap-2 rounded px-2 py-1.5 text-base text-gray-900 ${giftDirty ? "bg-orange-50 ring-1 ring-orange-400" : ""}`}>
                           <input
                             type="checkbox"
                             checked={edit.isGiftOnly}
                             onChange={(e) => updateVariantField(v.id, v, "isGiftOnly", e.target.checked)}
-                            className="h-5 w-5 accent-gray-700"
+                            className="h-6 w-6 accent-gray-700"
                           />
                           贈答用
                         </label>
                       </td>
                       <td className="px-4 py-3">
-                        <label className={`flex items-center gap-2 rounded px-2 py-1 text-base text-gray-800 ${availDirty ? "bg-orange-50 ring-1 ring-orange-400" : ""}`}>
+                        <label className={`flex items-center gap-2 rounded px-2 py-1.5 text-base text-gray-900 ${availDirty ? "bg-orange-50 ring-1 ring-orange-400" : ""}`}>
                           <input
                             type="checkbox"
                             checked={edit.isAvailable}
                             onChange={(e) => updateVariantField(v.id, v, "isAvailable", e.target.checked)}
-                            className="h-5 w-5 accent-gray-700"
+                            className="h-6 w-6 accent-gray-700"
                           />
                           公開
                         </label>
@@ -323,7 +324,7 @@ export function ProductCard({
                       <td className="px-4 py-3 text-right">
                         <button
                           onClick={() => setDeleteVariantTarget({ variantId: v.id })}
-                          className="cursor-pointer rounded border border-red-300 px-4 py-2 text-sm font-medium text-red-600 transition-all duration-200 hover:border-red-500 hover:bg-red-600 hover:text-white"
+                          className="cursor-pointer rounded border border-red-300 px-5 py-2.5 text-base font-medium text-red-600 transition-all duration-200 hover:border-red-500 hover:bg-red-600 hover:text-white"
                         >
                           削除
                         </button>
@@ -333,9 +334,10 @@ export function ProductCard({
                 })}
               </tbody>
             </table>
+            </div>
             <button
               onClick={openAddVariantModal}
-              className="mt-3 cursor-pointer text-sm font-medium text-orange-600 hover:underline"
+              className="mt-3 cursor-pointer rounded-md px-3 py-2 text-base font-medium text-orange-600 hover:bg-orange-50"
             >
               + バリエーション追加
             </button>
@@ -346,13 +348,13 @@ export function ProductCard({
       <div className="mt-4 flex gap-3">
         <button
           onClick={onEdit}
-          className="cursor-pointer rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50"
+          className="cursor-pointer rounded border border-gray-300 bg-white px-5 py-3 text-base font-medium text-gray-900 hover:bg-gray-50"
         >
           編集
         </button>
         <button
           onClick={() => setDeleteProductTarget(true)}
-          className="cursor-pointer rounded border border-red-300 px-4 py-2 text-sm font-medium text-red-600 transition-all duration-200 hover:border-red-500 hover:bg-red-600 hover:text-white"
+          className="cursor-pointer rounded border border-red-300 px-5 py-3 text-base font-medium text-red-600 transition-all duration-200 hover:border-red-500 hover:bg-red-600 hover:text-white"
         >
           削除
         </button>
@@ -371,20 +373,20 @@ export function ProductCard({
           </AlertDialogHeader>
           <div className="space-y-4">
             <div>
-              <label className="block text-base font-medium text-gray-900">
+              <label className="block text-lg font-medium text-gray-900">
                 ラベル *
               </label>
               <input
                 placeholder="例: 3kg"
                 value={newVariant.label}
                 onChange={(e) => setNewVariant({ ...newVariant, label: e.target.value })}
-                className="mt-1 w-full rounded border p-2.5 text-base text-gray-900"
+                className="mt-1 w-full rounded border p-3 text-lg text-gray-900"
                 autoFocus
               />
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="block text-base font-medium text-gray-900">
+                <label className="block text-lg font-medium text-gray-900">
                   重量 (kg) *
                 </label>
                 <input
@@ -393,11 +395,11 @@ export function ProductCard({
                   placeholder="3"
                   value={newVariant.weightKg}
                   onChange={(e) => setNewVariant({ ...newVariant, weightKg: e.target.value })}
-                  className="mt-1 w-full rounded border p-2.5 text-base text-gray-900"
+                  className="mt-1 w-full rounded border p-3 text-lg text-gray-900"
                 />
               </div>
               <div>
-                <label className="block text-base font-medium text-gray-900">
+                <label className="block text-lg font-medium text-gray-900">
                   価格 (円) *
                 </label>
                 <input
@@ -405,16 +407,16 @@ export function ProductCard({
                   placeholder="1800"
                   value={newVariant.priceJpy}
                   onChange={(e) => setNewVariant({ ...newVariant, priceJpy: e.target.value })}
-                  className="mt-1 w-full rounded border p-2.5 text-base text-gray-900"
+                  className="mt-1 w-full rounded border p-3 text-lg text-gray-900"
                 />
               </div>
             </div>
-            <label className="flex items-center gap-2 text-base text-gray-900">
+            <label className="flex items-center gap-3 text-lg text-gray-900">
               <input
                 type="checkbox"
                 checked={newVariant.isGiftOnly}
                 onChange={(e) => setNewVariant({ ...newVariant, isGiftOnly: e.target.checked })}
-                className="h-5 w-5"
+                className="h-6 w-6"
               />
               贈答用
             </label>
@@ -449,7 +451,7 @@ export function ProductCard({
           <AlertDialogHeader>
             <AlertDialogTitle>商品を削除しますか？</AlertDialogTitle>
           </AlertDialogHeader>
-          <p className="text-base text-gray-700">
+          <p className="text-lg text-gray-900">
             この操作は取り消せません。商品に紐づくバリエーションもすべて削除されます。
           </p>
           <AlertDialogFooter>
@@ -475,7 +477,7 @@ export function ProductCard({
           <AlertDialogHeader>
             <AlertDialogTitle>バリエーションを削除しますか？</AlertDialogTitle>
           </AlertDialogHeader>
-          <p className="text-base text-gray-700">
+          <p className="text-lg text-gray-900">
             この操作は取り消せません。
           </p>
           <AlertDialogFooter>

--- a/src/components/admin/product-form.tsx
+++ b/src/components/admin/product-form.tsx
@@ -92,25 +92,25 @@ export function ProductForm({ editingProduct, onCreated, onUpdated, onCancel }: 
           handleCreate(e);
         }
       }}
-      className="mb-6 space-y-4 rounded-lg bg-white p-6 shadow-sm"
+      className="mb-6 space-y-4 rounded-lg bg-white p-5 shadow-sm sm:p-6"
     >
-      <h2 className="text-lg font-bold text-gray-900">
+      <h2 className="text-xl font-bold text-gray-900">
         {editingProduct ? "商品を編集" : "新しい商品を追加"}
       </h2>
       <div className="grid gap-3 sm:grid-cols-2">
         <div>
-          <label className="block text-base font-medium text-gray-900">
+          <label className="block text-lg font-medium text-gray-900">
             商品名 *
           </label>
           <input
             required
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="mt-1 w-full rounded border p-2.5 text-base text-gray-900"
+            className="mt-1 w-full rounded border p-3 text-lg text-gray-900"
           />
         </div>
         <div>
-          <label className="block text-base font-medium text-gray-900">
+          <label className="block text-lg font-medium text-gray-900">
             在庫 (kg)
           </label>
           <input
@@ -119,26 +119,26 @@ export function ProductForm({ editingProduct, onCreated, onUpdated, onCancel }: 
             min="0"
             value={stockKg}
             onChange={(e) => setStockKg(e.target.value)}
-            className="mt-1 w-full rounded border p-2.5 text-base text-gray-900"
+            className="mt-1 w-full rounded border p-3 text-lg text-gray-900"
           />
         </div>
       </div>
       <div>
-        <label className="block text-base font-medium text-gray-900">
+        <label className="block text-lg font-medium text-gray-900">
           説明
         </label>
         <input
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          className="mt-1 w-full rounded border p-2.5 text-base text-gray-900"
+          className="mt-1 w-full rounded border p-3 text-lg text-gray-900"
         />
       </div>
-      <label className="flex items-center gap-2 text-base text-gray-900">
+      <label className="flex items-center gap-3 text-lg text-gray-900">
         <input
           type="checkbox"
           checked={isAvailable}
           onChange={(e) => setIsAvailable(e.target.checked)}
-          className="h-5 w-5"
+          className="h-6 w-6"
         />
         公開する
       </label>
@@ -146,91 +146,95 @@ export function ProductForm({ editingProduct, onCreated, onUpdated, onCancel }: 
       {/* バリエーション（新規作成時のみ） */}
       {!editingProduct && (
         <div className="border-t pt-4">
-          <h3 className="mb-2 font-bold text-gray-900">バリエーション</h3>
+          <h3 className="mb-2 text-lg font-bold text-gray-900">バリエーション</h3>
           {variants.map((v, i) => (
-            <div key={i} className="mb-3 flex items-center gap-3">
-              <input
-                required
-                placeholder="ラベル (3kg)"
-                value={v.label}
-                onChange={(e) => {
-                  const newVars = [...variants];
-                  newVars[i] = { ...v, label: e.target.value };
-                  setVariants(newVars);
-                }}
-                className="w-36 rounded border p-2.5 text-base text-gray-900"
-              />
-              <input
-                required
-                type="number"
-                step="0.001"
-                placeholder="重量kg"
-                value={v.weightKg}
-                onChange={(e) => {
-                  const newVars = [...variants];
-                  newVars[i] = { ...v, weightKg: e.target.value };
-                  setVariants(newVars);
-                }}
-                className="w-32 rounded border p-2.5 text-base text-gray-900"
-              />
-              <input
-                required
-                type="number"
-                placeholder="価格"
-                value={v.priceJpy}
-                onChange={(e) => {
-                  const newVars = [...variants];
-                  newVars[i] = { ...v, priceJpy: e.target.value };
-                  setVariants(newVars);
-                }}
-                className="w-32 rounded border p-2.5 text-base text-gray-900"
-              />
-              <label className="flex items-center gap-2 text-base text-gray-700">
+            <div key={i} className="mb-3 rounded border border-gray-200 p-3 sm:border-0 sm:p-0">
+              <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center sm:gap-3">
                 <input
-                  type="checkbox"
-                  checked={v.isGiftOnly}
+                  required
+                  placeholder="ラベル (3kg)"
+                  value={v.label}
                   onChange={(e) => {
                     const newVars = [...variants];
-                    newVars[i] = { ...v, isGiftOnly: e.target.checked };
+                    newVars[i] = { ...v, label: e.target.value };
                     setVariants(newVars);
                   }}
-                  className="h-5 w-5"
+                  className="rounded border p-3 text-lg text-gray-900 sm:w-36"
                 />
-                贈答用
-              </label>
-              {variants.length > 1 && (
-                <button
-                  type="button"
-                  onClick={() => setVariants(variants.filter((_, j) => j !== i))}
-                  className="cursor-pointer text-base text-red-600"
-                >
-                  削除
-                </button>
-              )}
+                <input
+                  required
+                  type="number"
+                  step="0.001"
+                  placeholder="重量kg"
+                  value={v.weightKg}
+                  onChange={(e) => {
+                    const newVars = [...variants];
+                    newVars[i] = { ...v, weightKg: e.target.value };
+                    setVariants(newVars);
+                  }}
+                  className="rounded border p-3 text-lg text-gray-900 sm:w-32"
+                />
+                <input
+                  required
+                  type="number"
+                  placeholder="価格"
+                  value={v.priceJpy}
+                  onChange={(e) => {
+                    const newVars = [...variants];
+                    newVars[i] = { ...v, priceJpy: e.target.value };
+                    setVariants(newVars);
+                  }}
+                  className="rounded border p-3 text-lg text-gray-900 sm:w-32"
+                />
+                <div className="flex items-center justify-between">
+                  <label className="flex items-center gap-3 text-lg text-gray-900">
+                    <input
+                      type="checkbox"
+                      checked={v.isGiftOnly}
+                      onChange={(e) => {
+                        const newVars = [...variants];
+                        newVars[i] = { ...v, isGiftOnly: e.target.checked };
+                        setVariants(newVars);
+                      }}
+                      className="h-6 w-6"
+                    />
+                    贈答用
+                  </label>
+                  {variants.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setVariants(variants.filter((_, j) => j !== i))}
+                      className="cursor-pointer rounded px-2 py-1 text-base font-medium text-red-600 hover:bg-red-50 sm:ml-3"
+                    >
+                      削除
+                    </button>
+                  )}
+                </div>
+              </div>
             </div>
           ))}
           <button
             type="button"
             onClick={() => setVariants([...variants, { ...emptyVariant }])}
-            className="cursor-pointer text-base text-orange-600 hover:underline"
+            className="cursor-pointer rounded-md px-3 py-2 text-base font-medium text-orange-600 hover:bg-orange-50"
           >
             + バリエーション追加
           </button>
         </div>
       )}
 
-      <div className="flex gap-2">
+      <div className="flex gap-3">
         <button
           type="submit"
           disabled={submitting}
-          className="cursor-pointer rounded bg-orange-500 px-5 py-2.5 text-base font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+          className="cursor-pointer rounded bg-orange-500 px-6 py-3 text-lg font-medium text-white hover:bg-orange-600 disabled:opacity-50"
         >
           {submitting ? "保存中..." : editingProduct ? "更新する" : "追加する"}
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="cursor-pointer rounded bg-gray-200 px-5 py-2.5 text-base font-medium text-gray-900 hover:bg-gray-300"
+          className="cursor-pointer rounded bg-gray-200 px-6 py-3 text-lg font-medium text-gray-900 hover:bg-gray-300"
         >
           キャンセル
         </button>

--- a/src/components/admin/products-manager.tsx
+++ b/src/components/admin/products-manager.tsx
@@ -61,7 +61,7 @@ export function AdminProductsManager({
         <h1 className="text-2xl font-bold text-gray-900">商品管理</h1>
         <button
           onClick={openAddForm}
-          className="cursor-pointer rounded bg-orange-500 px-5 py-2.5 text-base font-medium text-white hover:bg-orange-600"
+          className="cursor-pointer rounded bg-orange-500 px-6 py-3 text-lg font-medium text-white hover:bg-orange-600"
         >
           + 商品を追加
         </button>
@@ -77,7 +77,7 @@ export function AdminProductsManager({
       )}
 
       {products.length === 0 ? (
-        <p className="text-gray-900">商品はありません</p>
+        <p className="text-lg text-gray-900">商品はありません</p>
       ) : (
         <div className="space-y-4">
           {products.map((product) => (

--- a/src/components/order-status-badge.tsx
+++ b/src/components/order-status-badge.tsx
@@ -23,7 +23,7 @@ const statusColors: Record<string, string> = {
 export function OrderStatusBadge({ status }: { status: string }) {
   return (
     <span
-      className={`inline-block rounded-full px-3 py-1.5 text-sm font-medium ${statusColors[status] ?? "bg-gray-100 text-gray-900"}`}
+      className={`inline-block rounded-full px-3 py-2 text-base font-medium ${statusColors[status] ?? "bg-gray-100 text-gray-900"}`}
     >
       {statusLabels[status] ?? status}
     </span>


### PR DESCRIPTION
## Summary
- 管理画面全体のスマホレスポンシブ対応（ナビ2段構成、テーブル横スクロール、フォーム縦積み）
- 50〜80代の老眼ユーザー向けアクセシビリティ改善（フォント18px基準、タップターゲット48px+、高コントラスト）
- text-sm全廃、チェックボックス拡大、select/ボタンの操作性向上

## Test plan
- [ ] スマホ実機（iPhone）で管理画面の各ページを確認
- [ ] 注文管理: フィルタ/ソートのselect操作、ステータス変更
- [ ] 商品管理: 商品追加フォーム、バリエーションテーブル展開
- [ ] 特商法表記: フォーム入力・保存
- [ ] ログインページ: Googleログインボタンのサイズ
- [ ] ナビゲーションリンクのタップしやすさ

🤖 Generated with [Claude Code](https://claude.com/claude-code)