### PR TITLE
chore: GitHub Actions CDパイプラインを追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,81 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: cd-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Run DB Migrations
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      executed: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+      - name: Check for migration changes
+        id: check
+        run: |
+          if git diff --quiet HEAD~1 -- drizzle/; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No migration changes detected. Skipping."
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Migration changes detected."
+          fi
+      - uses: pnpm/action-setup@v4
+        if: steps.check.outputs.has_changes == 'true'
+      - uses: actions/setup-node@v4
+        if: steps.check.outputs.has_changes == 'true'
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+        if: steps.check.outputs.has_changes == 'true'
+      - name: Run migrations
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: pnpm db:migrate
+
+  deploy:
+    name: Deploy to Vercel Production
+    needs: [migrate]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+      - name: Pull Vercel Environment
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: team_s7NFsfpUpIu4JHfK6XbEeIjA
+          VERCEL_PROJECT_ID: prj_PO3SzQlMaaaHg9PmaiNO43yR40wE
+      - name: Build with Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: team_s7NFsfpUpIu4JHfK6XbEeIjA
+          VERCEL_PROJECT_ID: prj_PO3SzQlMaaaHg9PmaiNO43yR40wE
+      - name: Deploy to Production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: team_s7NFsfpUpIu4JHfK6XbEeIjA
+          VERCEL_PROJECT_ID: prj_PO3SzQlMaaaHg9PmaiNO43yR40wE

--- a/.github/workflows/token-expiry-check.yml
+++ b/.github/workflows/token-expiry-check.yml
@@ -1,0 +1,70 @@
+name: Token Expiry Check
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # 毎週月曜 UTC 00:00
+  workflow_dispatch: # 手動実行も可能
+
+jobs:
+  check:
+    name: Check Vercel Token Expiry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check expiry date
+        env:
+          EXPIRES_AT: ${{ vars.VERCEL_TOKEN_EXPIRES_AT }}
+        run: |
+          if [ -z "$EXPIRES_AT" ]; then
+            echo "::warning::VERCEL_TOKEN_EXPIRES_AT variable is not set."
+            exit 0
+          fi
+
+          expires_ts=$(date -d "$EXPIRES_AT" +%s)
+          now_ts=$(date +%s)
+          days_left=$(( (expires_ts - now_ts) / 86400 ))
+
+          echo "Token expires: $EXPIRES_AT ($days_left days left)"
+
+          if [ "$days_left" -le 7 ]; then
+            echo "should_notify=true" >> $GITHUB_ENV
+            echo "days_left=$days_left" >> $GITHUB_ENV
+          else
+            echo "should_notify=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create issue for token renewal
+        if: env.should_notify == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list --repo ${{ github.repository }} --label "token-renewal" --state open --json number --jq '.[0].number')
+
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already exists. Skipping."
+            exit 0
+          fi
+
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "Vercel Token が ${{ env.days_left }} 日後に期限切れになります" \
+            --label "token-renewal" \
+            --body "$(cat <<'EOF'
+          ## Vercel Token の更新が必要です
+
+          **期限日**: ${{ vars.VERCEL_TOKEN_EXPIRES_AT }}
+          **残り日数**: ${{ env.days_left }} 日
+
+          ### 更新手順
+
+          1. [Vercel Tokens ページ](https://vercel.com/account/tokens) で新しいトークンを作成（Scope: Full Account, 期限: 90日）
+          2. GitHub Secret を更新:
+             ```bash
+             gh secret set VERCEL_TOKEN --repo yuyakondo333/mikan-order
+             ```
+          3. GitHub Variable を更新:
+             ```bash
+             gh variable set VERCEL_TOKEN_EXPIRES_AT --repo yuyakondo333/mikan-order --body "YYYY-MM-DD"
+             ```
+          4. このissueをクローズ
+          EOF
+          )"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "setup:richmenu": "npx tsx scripts/setup-richmenu.ts"
+    "setup:richmenu": "npx tsx scripts/setup-richmenu.ts",
+    "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",


### PR DESCRIPTION
## Summary
- CI成功後にVercelへ自動本番デプロイ（`workflow_run`トリガー）
- `drizzle/` 変更時のみ本番DBマイグレーション自動実行（変更なしはスキップ）
- Vercel Token期限通知ワークフロー（毎週チェック、7日前にissue作成）
- `db:migrate` スクリプト追加

## 設定済み（手動）
- [x] `VERCEL_TOKEN` GitHub Secret
- [x] `PRODUCTION_DATABASE_URL` GitHub Secret
- [x] `VERCEL_TOKEN_EXPIRES_AT` GitHub Variable (`2026-06-20`)
- [x] Vercel Ignored Build Step → `exit 0`（二重デプロイ防止）

## パイプライン
```
PRマージ → CI (ci.yml) → CD (cd.yml)
                           ├── migrate (drizzle/変更時のみ)
                           └── deploy (vercel build → deploy --prod)
```

## Test plan
- [ ] CIが全パスすることを確認
- [ ] mainマージ後にCDワークフローが自動起動されることを確認
- [ ] Vercelダッシュボードでデプロイ成功を確認
- [ ] 本番サイトにアクセスして動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)