### PR TITLE
fix: Server Actionエラー表示をsonner toast.error()に統一

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "19.2.3",
     "server-only": "^0.0.1",
     "shadcn": "^4.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       shadcn:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@20.19.33)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3698,6 +3701,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -7952,6 +7961,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/actions/cart.ts
+++ b/src/app/actions/cart.ts
@@ -81,57 +81,67 @@ export async function updateCartItemByVariant(
   variantId: string,
   quantity: number
 ): Promise<CartActionResult> {
-  const user = await getAuthenticatedUser();
-  if (!user) return { success: false, error: "認証が必要です" };
+  try {
+    const user = await getAuthenticatedUser();
+    if (!user) return { success: false, error: "認証が必要です" };
 
-  if (quantity < 1) {
-    return { success: false, error: "数量は1以上を指定してください" };
+    if (quantity < 1) {
+      return { success: false, error: "数量は1以上を指定してください" };
+    }
+
+    const variant = await db.query.productVariants.findFirst({
+      where: eq(productVariants.id, variantId),
+    });
+    if (!variant) {
+      return { success: false, error: "バリエーションが見つかりません" };
+    }
+    if (!variant.isAvailable) {
+      return {
+        success: false,
+        error: "このバリエーションは現在販売されていません",
+      };
+    }
+
+    const product = await db.query.products.findFirst({
+      where: eq(products.id, variant.productId),
+    });
+    if (!product || !product.isAvailable) {
+      return { success: false, error: "この商品は現在販売されていません" };
+    }
+
+    const required = calcStockConsumptionKg(quantity, variant.weightKg);
+    if (required > product.stockKg) {
+      return { success: false, error: "在庫が不足しています" };
+    }
+
+    await upsertCartItemByVariant(
+      user.id,
+      variantId,
+      variant.productId,
+      quantity
+    );
+
+    revalidateCartPages();
+    return { success: true };
+  } catch (e) {
+    console.error("Failed to update cart item:", e);
+    return { success: false, error: "カートの更新に失敗しました" };
   }
-
-  const variant = await db.query.productVariants.findFirst({
-    where: eq(productVariants.id, variantId),
-  });
-  if (!variant) {
-    return { success: false, error: "バリエーションが見つかりません" };
-  }
-  if (!variant.isAvailable) {
-    return {
-      success: false,
-      error: "このバリエーションは現在販売されていません",
-    };
-  }
-
-  const product = await db.query.products.findFirst({
-    where: eq(products.id, variant.productId),
-  });
-  if (!product || !product.isAvailable) {
-    return { success: false, error: "この商品は現在販売されていません" };
-  }
-
-  const required = calcStockConsumptionKg(quantity, variant.weightKg);
-  if (required > product.stockKg) {
-    return { success: false, error: "在庫が不足しています" };
-  }
-
-  await upsertCartItemByVariant(
-    user.id,
-    variantId,
-    variant.productId,
-    quantity
-  );
-
-  revalidateCartPages();
-  return { success: true };
 }
 
 export async function removeCartItemByVariant(
   variantId: string
 ): Promise<CartActionResult> {
-  const user = await getAuthenticatedUser();
-  if (!user) return { success: false, error: "認証が必要です" };
+  try {
+    const user = await getAuthenticatedUser();
+    if (!user) return { success: false, error: "認証が必要です" };
 
-  await deleteCartItemByVariant(user.id, variantId);
+    await deleteCartItemByVariant(user.id, variantId);
 
-  revalidateCartPages();
-  return { success: true };
+    revalidateCartPages();
+    return { success: true };
+  } catch (e) {
+    console.error("Failed to remove cart item:", e);
+    return { success: false, error: "商品の削除に失敗しました" };
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -31,6 +32,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Toaster position="bottom-center" richColors />
       </body>
     </html>
   );

--- a/src/components/admin/orders-table.tsx
+++ b/src/components/admin/orders-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import { OrderStatusBadge } from "@/components/order-status-badge";
 import { updateOrderStatusByVariantAction } from "@/app/actions/orders";
 import { TIME_SLOT_LABELS, formatPickupDate } from "@/lib/constants";
@@ -84,10 +85,22 @@ export function AdminOrdersTable({
   }, [orders, filterStatus, sortOrder]);
 
   async function updateStatus(orderId: string, status: string) {
-    await updateOrderStatusByVariantAction(orderId, status);
+    const previousStatus = orders.find((o) => o.id === orderId)?.status;
     setOrders((prev) =>
       prev.map((o) => (o.id === orderId ? { ...o, status } : o))
     );
+
+    const result = await updateOrderStatusByVariantAction(orderId, status);
+    if (!result.success) {
+      toast.error(result.error || "ステータスの更新に失敗しました");
+      if (previousStatus) {
+        setOrders((prev) =>
+          prev.map((o) =>
+            o.id === orderId ? { ...o, status: previousStatus } : o
+          )
+        );
+      }
+    }
   }
 
   function getStatusOptions(fulfillmentMethod: string) {

--- a/src/components/admin/product-card.tsx
+++ b/src/components/admin/product-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   toggleProductAvailabilityAction,
   deleteProductAction,
@@ -95,6 +96,8 @@ export function ProductCard({
     );
     if (result.success) {
       onProductChange({ ...product, isAvailable: !product.isAvailable });
+    } else {
+      toast.error(result.error || "販売状態の変更に失敗しました");
     }
   }
 
@@ -102,6 +105,8 @@ export function ProductCard({
     const result = await deleteProductAction(product.id);
     if (result.success) {
       onProductDelete(product.id);
+    } else {
+      toast.error(result.error || "商品の削除に失敗しました");
     }
     setDeleteProductTarget(false);
   }
@@ -133,6 +138,8 @@ export function ProductCard({
           ...product,
           variants: [...product.variants, result.variant],
         });
+      } else if (!result.success) {
+        toast.error(result.error || "バリエーションの追加に失敗しました");
       }
     } finally {
       setAddingVariant(false);
@@ -143,7 +150,7 @@ export function ProductCard({
   async function handleDeleteVariant(variantId: string) {
     const result = await deleteVariantAction(variantId, product.id);
     if (!result.success) {
-      alert(result.error);
+      toast.error(result.error || "バリエーションの削除に失敗しました");
     } else {
       onProductChange({
         ...product,
@@ -180,6 +187,11 @@ export function ProductCard({
 
       const updated = buildProductsAfterVariantSave([product], product.id, results);
       onProductChange(updated[0]);
+
+      const failedCount = results.filter((r) => !r.success).length;
+      if (failedCount > 0) {
+        toast.error(`${failedCount}件のバリエーション保存に失敗しました`);
+      }
 
       // 成功分のeditsをクリア、失敗分はeditsに残す
       setVariantEdits((prev) => {

--- a/src/components/cart-content.tsx
+++ b/src/components/cart-content.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition } from "react";
 import Link from "next/link";
+import { toast } from "sonner";
 import { CartItem } from "@/components/cart-item";
 import {
   updateCartItemByVariant,
@@ -14,13 +15,19 @@ export function CartContent({ items }: { items: CartItemWithVariant[] }) {
 
   function handleUpdateQuantity(variantId: string, quantity: number) {
     startTransition(async () => {
-      await updateCartItemByVariant(variantId, quantity);
+      const result = await updateCartItemByVariant(variantId, quantity);
+      if (!result.success) {
+        toast.error(result.error || "カートの更新に失敗しました");
+      }
     });
   }
 
   function handleRemove(variantId: string) {
     startTransition(async () => {
-      await removeCartItemByVariant(variantId);
+      const result = await removeCartItemByVariant(variantId);
+      if (!result.success) {
+        toast.error(result.error || "商品の削除に失敗しました");
+      }
     });
   }
 

--- a/src/components/confirm-content.tsx
+++ b/src/components/confirm-content.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useSyncExternalStore, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { TIME_SLOT_LABELS, formatPickupDate } from "@/lib/constants";
 import { createOrderByVariant } from "@/app/actions/orders";
 import type { CartItemWithVariant } from "@/types";
@@ -69,7 +70,7 @@ export function ConfirmContent({ items }: { items: CartItemWithVariant[] }) {
         sessionStorage.removeItem("orderFulfillment");
         router.push(`/complete?method=${result.fulfillmentMethod}`);
       } else {
-        alert(result.error || "注文に失敗しました");
+        toast.error(result.error || "注文に失敗しました");
       }
     });
   }

--- a/src/components/product-list.tsx
+++ b/src/components/product-list.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useTransition } from "react";
+import { toast } from "sonner";
 import { ProductCard } from "@/components/product-card";
 import { addToCartByVariant } from "@/app/actions/cart";
 import type { ProductWithVariants } from "@/types";
 
 export function ProductList({ products }: { products: ProductWithVariants[] }) {
-  const [toast, setToast] = useState<string | null>(null);
   const [, startTransition] = useTransition();
 
   function handleAddToCart(variantId: string, quantity: number, productName: string) {
@@ -14,37 +14,26 @@ export function ProductList({ products }: { products: ProductWithVariants[] }) {
       const result = await addToCartByVariant(variantId, quantity);
 
       if (result.success) {
-        setToast(`${productName} を ${quantity}個 カートに追加しました`);
-        setTimeout(() => setToast(null), 2000);
+        toast.success(`${productName} を ${quantity}個 カートに追加しました`);
       } else {
-        setToast(result.error);
-        setTimeout(() => setToast(null), 3000);
+        toast.error(result.error || "カートへの追加に失敗しました");
       }
     });
   }
 
-  return (
-    <>
-      {products.length === 0 ? (
-        <p className="text-center text-gray-500">
-          現在販売中の商品はありません
-        </p>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {products.map((product) => (
-            <ProductCard
-              key={product.id}
-              product={product}
-              onAddToCart={handleAddToCart}
-            />
-          ))}
-        </div>
-      )}
-      {toast && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 rounded-full bg-gray-800 px-6 py-3 text-sm text-white shadow-lg">
-          {toast}
-        </div>
-      )}
-    </>
+  return products.length === 0 ? (
+    <p className="text-center text-gray-500">
+      現在販売中の商品はありません
+    </p>
+  ) : (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {products.map((product) => (
+        <ProductCard
+          key={product.id}
+          product={product}
+          onAddToCart={handleAddToCart}
+        />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- sonnerを導入し、全Server Actionのエラー表示を`toast.error()`に統一
- `alert()`の完全廃止、`console.error`のみだった箇所にユーザー向け通知を追加
- `product-list.tsx`の手製カスタムtoastもsonnerに置換

## Changes
| ファイル | Before | After |
|---|---|---|
| `confirm-content.tsx` | `alert()` | `toast.error()` |
| `cart-content.tsx` | エラー無視 | `toast.error()` |
| `admin/product-card.tsx` | 大半無視 + 一部`alert()` | 全Action `toast.error()` |
| `admin/orders-table.tsx` | エラー無視（DB乖離） | 楽観更新 + ロールバック + `toast.error()` |
| `product-list.tsx` | 手製toast | `toast.success()` / `toast.error()` |
| `cart.ts` | try-catchなし | try-catch追加 |

## Test plan
- [ ] 顧客: 商品をカートに追加 → 成功toastが表示される
- [ ] 顧客: カート数量変更/削除が失敗した場合 → エラーtoastが表示される
- [ ] 顧客: 注文確認で失敗した場合 → エラーtoastが表示される（alertではない）
- [ ] 管理: 商品の販売状態切替/削除が失敗した場合 → エラーtoastが表示される
- [ ] 管理: バリエーション追加/保存/削除が失敗した場合 → エラーtoastが表示される
- [ ] 管理: 注文ステータス変更が失敗した場合 → エラーtoast + ステータスがロールバックされる

closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)