### PR TITLE
refactor: OrderStatus型の3重定義をDB enum起点に一元化

### DIFF
--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,15 +1,9 @@
 import { z } from "zod";
+import { orderStatusEnum } from "@/db/schema";
 
-export const orderStatusSchema = z.enum([
-  "pending",
-  "awaiting_payment",
-  "payment_confirmed",
-  "preparing",
-  "ready",
-  "shipped",
-  "completed",
-  "cancelled",
-]);
+export const orderStatusSchema = z.enum(orderStatusEnum.enumValues);
+
+export type OrderStatus = z.infer<typeof orderStatusSchema>;
 
 export const addressSchema = z.object({
   recipientName: z.string().min(1, "受取人名を入力してください"),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,15 +47,7 @@ export type FulfillmentMethod = "pickup" | "delivery";
 
 export type PickupTimeSlot = "morning" | "early_afternoon" | "late_afternoon";
 
-export type OrderStatus =
-  | "pending"
-  | "awaiting_payment"
-  | "payment_confirmed"
-  | "preparing"
-  | "ready"
-  | "shipped"
-  | "completed"
-  | "cancelled";
+export type { OrderStatus } from "@/lib/validations";
 
 export type Order = {
   id: string;


### PR DESCRIPTION
## Summary
- `orderStatusSchema` を `orderStatusEnum.enumValues` から導出し、手動列挙を削除
- `OrderStatus` 型を `z.infer<typeof orderStatusSchema>` で導出し、`types/index.ts` から re-export
- DB enum (`src/db/schema.ts`) が唯一のソースとなり、ステータス追加時の同期漏れリスクを解消

## Test plan
- [x] 全テスト170件パス
- [x] TypeScript型チェック（変更ファイル起因のエラーなし）

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)