### PR TITLE
fix: updateOrderStatusにorderId存在チェックを追加

### DIFF
--- a/src/app/actions/orders-variant.test.ts
+++ b/src/app/actions/orders-variant.test.ts
@@ -69,6 +69,7 @@ const mockGetCartWithVariants = vi.mocked(getCartWithVariants);
 const mockCalcConsumption = vi.mocked(calcStockConsumptionKg);
 const mockRestoreStockKg = vi.mocked(restoreStockKg);
 const mockGetOrderV2 = vi.mocked(getOrderWithUserAndItemsV2);
+const mockUpdateOrderStatus = vi.mocked(updateOrderStatus);
 const mockSendShipping = vi.mocked(sendShippingNotification);
 const mockGetPaymentSettings = vi.mocked(getPaymentSettings);
 const mockSendBankTransfer = vi.mocked(sendOrderConfirmationWithBankTransfer);
@@ -443,6 +444,7 @@ describe("createOrderByVariant", () => {
 describe("updateOrderStatusByVariantAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUpdateOrderStatus.mockResolvedValue({ id: "order-1" });
   });
 
   // F1: 非管理者 → エラー
@@ -662,5 +664,50 @@ describe("updateOrderStatusByVariantAction", () => {
 
     expect(result).toEqual({ success: true });
     expect(mockSendShipping).not.toHaveBeenCalled();
+  });
+
+  it("存在しないorderIdでエラーを返し、revalidatePathが呼ばれない", async () => {
+    mockAuth.mockResolvedValue({
+      user: { role: "admin", email: "admin@example.com" },
+      expires: "",
+    } as Session);
+    mockUpdateOrderStatus.mockResolvedValue(null);
+
+    const result = await updateOrderStatusByVariantAction("non-existent-id", "pending");
+
+    expect(result).toEqual({ success: false, error: "注文が見つかりません" });
+    expect(mockUpdateOrderStatus).toHaveBeenCalledWith("non-existent-id", "pending");
+    expect(vi.mocked(revalidatePath)).not.toHaveBeenCalled();
+  });
+
+  it("存在しないorderIdでキャンセル→在庫復元されず、エラーが返る", async () => {
+    mockAuth.mockResolvedValue({
+      user: { role: "admin", email: "admin@example.com" },
+      expires: "",
+    } as Session);
+    mockGetOrderV2.mockResolvedValue(null);
+    mockUpdateOrderStatus.mockResolvedValue(null);
+
+    const result = await updateOrderStatusByVariantAction("non-existent-id", "cancelled");
+
+    expect(result).toEqual({ success: false, error: "注文が見つかりません" });
+    expect(mockRestoreStockKg).not.toHaveBeenCalled();
+    expect(mockUpdateOrderStatus).toHaveBeenCalledWith("non-existent-id", "cancelled");
+    expect(vi.mocked(revalidatePath)).not.toHaveBeenCalled();
+  });
+
+  it("存在しないorderIdでshipped→LINE通知が送られず、エラーが返る", async () => {
+    mockAuth.mockResolvedValue({
+      user: { role: "admin", email: "admin@example.com" },
+      expires: "",
+    } as Session);
+    mockUpdateOrderStatus.mockResolvedValue(null);
+
+    const result = await updateOrderStatusByVariantAction("non-existent-id", "shipped");
+
+    expect(result).toEqual({ success: false, error: "注文が見つかりません" });
+    expect(mockUpdateOrderStatus).toHaveBeenCalledWith("non-existent-id", "shipped");
+    expect(mockSendShipping).not.toHaveBeenCalled();
+    expect(vi.mocked(revalidatePath)).not.toHaveBeenCalled();
   });
 });

--- a/src/app/actions/orders.ts
+++ b/src/app/actions/orders.ts
@@ -223,7 +223,10 @@ export async function updateOrderStatusByVariantAction(
       }
     }
 
-    await updateOrderStatus(orderId, validatedStatus);
+    const updated = await updateOrderStatus(orderId, validatedStatus);
+    if (!updated) {
+      return { success: false, error: "注文が見つかりません" };
+    }
 
     // 発送完了 → LINE通知（delivery注文のみ）
     if (validatedStatus === "shipped") {

--- a/src/db/queries/orders.ts
+++ b/src/db/queries/orders.ts
@@ -78,9 +78,11 @@ export const getOrderDetailV2 = cache(async function getOrderDetailV2(id: string
 export async function updateOrderStatus(
   orderId: string,
   status: OrderStatus
-) {
-  await db
+): Promise<{ id: string } | null> {
+  const [result] = await db
     .update(orders)
     .set({ status })
-    .where(eq(orders.id, orderId));
+    .where(eq(orders.id, orderId))
+    .returning({ id: orders.id });
+  return result ?? null;
 }


### PR DESCRIPTION
## Summary
- DAL層 `updateOrderStatus` に `.returning({ id })` を追加し、0件更新時に `null` を返すよう変更
- Server Action層で `null` チェックを追加し、存在しない `orderId` に対して明示的なエラーを返す
- 新規テスト3件追加（通常/キャンセル/shipped × 存在しないorderId）

## 変更理由
存在しない `orderId` に対する UPDATE が0件更新で無音成功していた（Issue #148）。Server Action が直接呼ばれた場合に不正な `orderId` でもエラーにならない問題を修正。

## レビューポイント
- DAL: `.returning({ id: orders.id })` でIDのみ取得（フル行転送を避ける）
- Server Action: `updateOrderStatus` 後の null チェックの位置（キャンセル時の在庫復元は既存設計のまま）
- テスト: `beforeEach` のデフォルトモック追加が既存テストに影響しないこと

## Test plan
- [x] 存在しないorderIdでステータス更新→エラー + revalidatePath未呼出
- [x] 存在しないorderIdでキャンセル→在庫復元なし + エラー
- [x] 存在しないorderIdでshipped→LINE通知なし + エラー
- [x] 既存テスト全27件パス
- [x] 全テスト173件パス / Lint error 0 / Build成功

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)