### PR TITLE
fix: エラーページで内部エラーメッセージを非表示にする

### DIFF
--- a/src/app/(customer)/error.tsx
+++ b/src/app/(customer)/error.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 export default function CustomerError({
   error,
   reset,
@@ -7,12 +9,24 @@ export default function CustomerError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-orange-50 p-4">
       <div className="rounded-lg bg-red-50 p-6 text-center">
-        <p className="text-red-600">
-          {error.message || "エラーが発生しました"}
+        <p className="text-lg font-semibold text-red-600">
+          エラーが発生しました
         </p>
+        <p className="mt-2 text-sm text-gray-600">
+          しばらく時間をおいてから再度お試しください。
+        </p>
+        {error.digest && (
+          <p className="mt-2 text-xs text-gray-400">
+            エラーID: {error.digest}
+          </p>
+        )}
         <button
           onClick={() => reset()}
           className="mt-4 cursor-pointer rounded-full bg-orange-500 px-6 py-2 text-sm font-medium text-white hover:bg-orange-600"

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 export default function AdminError({
   error,
   reset,
@@ -7,12 +9,24 @@ export default function AdminError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
   return (
     <div className="flex items-center justify-center py-12">
       <div className="rounded-lg bg-red-50 p-6 text-center">
-        <p className="text-red-600">
-          {error.message || "エラーが発生しました"}
+        <p className="text-lg font-semibold text-red-600">
+          エラーが発生しました
         </p>
+        <p className="mt-2 text-sm text-gray-600">
+          しばらく時間をおいてから再度お試しください。
+        </p>
+        {error.digest && (
+          <p className="mt-2 text-xs text-gray-400">
+            エラーID: {error.digest}
+          </p>
+        )}
         <button
           onClick={() => reset()}
           className="mt-4 cursor-pointer rounded bg-gray-800 px-4 py-2 text-sm text-white hover:bg-gray-900"

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body>
+        <div
+          style={{
+            display: "flex",
+            minHeight: "100vh",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "1rem",
+            fontFamily: "sans-serif",
+          }}
+        >
+          <div style={{ textAlign: "center" }}>
+            <p
+              style={{
+                fontSize: "1.125rem",
+                fontWeight: 600,
+                color: "#dc2626",
+              }}
+            >
+              エラーが発生しました
+            </p>
+            <p
+              style={{
+                marginTop: "0.5rem",
+                fontSize: "0.875rem",
+                color: "#4b5563",
+              }}
+            >
+              しばらく時間をおいてから再度お試しください。
+            </p>
+            {error.digest && (
+              <p
+                style={{
+                  marginTop: "0.5rem",
+                  fontSize: "0.75rem",
+                  color: "#9ca3af",
+                }}
+              >
+                エラーID: {error.digest}
+              </p>
+            )}
+            <button
+              onClick={() => reset()}
+              style={{
+                marginTop: "1rem",
+                padding: "0.5rem 1.5rem",
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                color: "#ffffff",
+                backgroundColor: "#f97316",
+                border: "none",
+                borderRadius: "9999px",
+                cursor: "pointer",
+              }}
+            >
+              再試行
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- エラーページで `error.message` を直接表示していたのを、固定の汎用メッセージに変更
- `global-error.tsx` を追加してルートレイアウトのエラーもカバー
- `digest` がある場合はエラーIDとして表示（問い合わせ時の特定用）
- `console.error` でログ出力を追加（開発時のデバッグ用）

## Why
内部的なエラーメッセージ（DB接続エラーの詳細等）がユーザーに表示される可能性があった。

## Test plan
- [ ] 顧客画面でエラー発生時に汎用メッセージが表示されること
- [ ] 管理画面でエラー発生時に汎用メッセージが表示されること
- [ ] ルートレイアウトエラー時にglobal-errorが表示されること
- [ ] ブラウザコンソールにエラー詳細がログ出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)