### PR TITLE
fix: 顧客向けページのキャッシュによるデータ未反映を修正

### DIFF
--- a/src/app/(customer)/address/page.tsx
+++ b/src/app/(customer)/address/page.tsx
@@ -3,6 +3,8 @@ import { verifySession } from "@/lib/dal";
 import { getLatestAddressByLineUserId } from "@/db/queries/addresses";
 import { AddressForm } from "@/components/address-form";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "受取方法",
 };

--- a/src/app/(customer)/cart/page.tsx
+++ b/src/app/(customer)/cart/page.tsx
@@ -4,6 +4,8 @@ import { getCartWithVariants } from "@/db/queries/cart";
 import { getAuthenticatedUser } from "@/lib/dal";
 import type { CartItemWithVariant } from "@/types";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "カート",
 };

--- a/src/app/(customer)/confirm/page.tsx
+++ b/src/app/(customer)/confirm/page.tsx
@@ -5,6 +5,8 @@ import { getCartWithVariants } from "@/db/queries/cart";
 import { getAuthenticatedUser } from "@/lib/dal";
 import type { CartItemWithVariant } from "@/types";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "注文内容の確認",
 };

--- a/src/app/(customer)/orders/[id]/page.tsx
+++ b/src/app/(customer)/orders/[id]/page.tsx
@@ -5,6 +5,8 @@ import { getAuthenticatedUser } from "@/lib/dal";
 import { OrderDetailView } from "@/components/order-detail-view";
 import { notFound } from "next/navigation";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/(customer)/orders/page.tsx
+++ b/src/app/(customer)/orders/page.tsx
@@ -3,6 +3,8 @@ import { verifySession } from "@/lib/dal";
 import { getOrdersByLineUserId } from "@/db/queries/orders";
 import { OrdersList } from "@/components/orders-list";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "注文履歴",
 };

--- a/src/app/(customer)/products/page.tsx
+++ b/src/app/(customer)/products/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { getAvailableProductsWithVariants } from "@/db/queries/products";
 import { ProductList } from "@/components/product-list";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "商品一覧",
 };


### PR DESCRIPTION
## Summary
- 管理画面で在庫を更新しても、顧客向け（LIFF）の商品一覧に反映されない問題を修正
- 原因: 顧客向けページに `dynamic = "force-dynamic"` が未設定で、Vercel上でキャッシュされた古いデータが返されていた
- DB依存の全顧客向けページ6件に `export const dynamic = "force-dynamic"` を追加

## 対象ページ
| ページ | パス |
|--------|------|
| 商品一覧 | `/products` |
| カート | `/cart` |
| 注文履歴 | `/orders` |
| 注文詳細 | `/orders/[id]` |
| 受取方法 | `/address` |
| 注文確認 | `/confirm` |

※ `/complete`（DB非依存）と `/help`（静的コンテンツ）は対象外

## Test plan
- [ ] デプロイ後、管理画面で在庫を変更し、顧客向け商品一覧に即座に反映されることを確認
- [ ] カート・注文履歴等の他ページでも最新データが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)