### PR TITLE
debug: 注文作成エラーの詳細表示（一時的）

### DIFF
--- a/src/app/actions/orders.ts
+++ b/src/app/actions/orders.ts
@@ -190,7 +190,8 @@ export async function createOrderByVariant(
     if (e instanceof Error && e.message.includes("在庫")) {
       return { success: false, error: e.message };
     }
-    return { success: false, error: "注文の作成に失敗しました" };
+    const debugMsg = e instanceof Error ? e.message : String(e);
+    return { success: false, error: `注文の作成に失敗しました: ${debugMsg}` };
   }
 }
 


### PR DESCRIPTION
## Summary
- 注文作成失敗時のエラーメッセージに実際のエラー内容を含めるように変更
- 原因特定後に元に戻す

## 目的
本番で「注文の作成に失敗しました」とだけ表示され、原因が特定できないため、一時的にデバッグ情報を表示する