### PR TITLE
fix: updateProductのMass Assignment脆弱性を修正 (#111)

### DIFF
--- a/src/app/actions/products.ts
+++ b/src/app/actions/products.ts
@@ -121,7 +121,7 @@ export async function updateProductV2Action(
         return { success: false, error: "バリエーションがない商品は公開できません" };
       }
     }
-    await updateProduct(id, data as never);
+    await updateProduct(id, data);
     revalidatePath("/admin/products");
     revalidatePath("/products");
     return { success: true };

--- a/src/db/queries/products.ts
+++ b/src/db/queries/products.ts
@@ -67,7 +67,12 @@ export async function createProduct(data: {
 
 export async function updateProduct(
   id: string,
-  data: Partial<Record<string, unknown>>
+  data: Partial<{
+    name: string;
+    stockKg: number;
+    description: string | null;
+    isAvailable: boolean;
+  }>
 ) {
   await db.update(products).set(data).where(eq(products.id, id));
 }


### PR DESCRIPTION
## Summary
- `updateProduct` の引数型を `Partial<Record<string, unknown>>` から許可フィールドのみの型に変更
- `updateProductV2Action` の `as never` キャストを排除
- 許可フィールド: `name`, `stockKg`, `description`, `isAvailable`

## Why
`updateProduct` が任意のキーを受け取れる状態で、`id`, `createdAt` 等の保護すべきカラムも理論上書き込み可能だった（Mass Assignment脆弱性）。

## Changes
- `src/db/queries/products.ts`: `updateProduct` の `data` 引数を具体的な型に変更
- `src/app/actions/products.ts`: `as never` キャスト削除（型が一致するため不要に）

## Test plan
- [x] 既存テスト全通過（260/260）
- [x] TypeScriptビルド成功（`as never` なしで型チェック通過）
- [x] Lint 0 errors

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)