### PR TITLE
fix: 管理画面ページにverifyAdmin()多層防御を追加

### DIFF
--- a/src/app/admin/legal/page.tsx
+++ b/src/app/admin/legal/page.tsx
@@ -1,8 +1,10 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getLegalInfo } from "@/db/queries/legal-info";
 import { LegalInfoEditor } from "@/components/admin/legal-info-editor";
 import { LegalFormSkeleton } from "@/components/admin/skeletons";
+import { verifyAdmin } from "@/lib/admin-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +17,9 @@ async function LegalData() {
   return <LegalInfoEditor initialData={info} />;
 }
 
-export default function AdminLegalPage() {
+export default async function AdminLegalPage() {
+  const isAdmin = await verifyAdmin();
+  if (!isAdmin) redirect("/admin/login");
   return (
     <Suspense fallback={<LegalFormSkeleton />}>
       <LegalData />

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,8 +1,10 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getAllOrders } from "@/db/queries/orders";
 import { AdminOrdersTable } from "@/components/admin/orders-table";
 import { OrdersTableSkeleton } from "@/components/admin/skeletons";
+import { verifyAdmin } from "@/lib/admin-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +17,9 @@ async function OrdersData() {
   return <AdminOrdersTable initialOrders={orders} />;
 }
 
-export default function AdminOrdersPage() {
+export default async function AdminOrdersPage() {
+  const isAdmin = await verifyAdmin();
+  if (!isAdmin) redirect("/admin/login");
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-gray-900">注文管理</h1>

--- a/src/app/admin/payment/page.tsx
+++ b/src/app/admin/payment/page.tsx
@@ -1,7 +1,9 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getPaymentSettings } from "@/db/queries/payment-settings";
 import { PaymentSettingsEditor } from "@/components/admin/payment-settings-editor";
+import { verifyAdmin } from "@/lib/admin-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +16,9 @@ async function PaymentData() {
   return <PaymentSettingsEditor initialData={settings} />;
 }
 
-export default function AdminPaymentPage() {
+export default async function AdminPaymentPage() {
+  const isAdmin = await verifyAdmin();
+  if (!isAdmin) redirect("/admin/login");
   return (
     <Suspense
       fallback={

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -1,8 +1,10 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getAllProductsWithVariants } from "@/db/queries/products";
 import { AdminProductsManager } from "@/components/admin/products-manager";
 import { ProductsListSkeleton } from "@/components/admin/skeletons";
+import { verifyAdmin } from "@/lib/admin-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +17,9 @@ async function ProductsData() {
   return <AdminProductsManager initialProducts={products} />;
 }
 
-export default function AdminProductsPage() {
+export default async function AdminProductsPage() {
+  const isAdmin = await verifyAdmin();
+  if (!isAdmin) redirect("/admin/login");
   return (
     <Suspense fallback={<ProductsManagerSkeleton />}>
       <ProductsData />


### PR DESCRIPTION
## Summary

- 管理画面の全ページServer Component（orders, products, payment, legal）の冒頭で `verifyAdmin()` を呼び出し、非adminはログインページへリダイレクトするよう変更
- ミドルウェアバイパス時に注文の配送先住所・氏名・電話番号が露出するリスクを軽減（Defence in Depth）

## 多層防御の構成

| レイヤー | 対象 | 状態 |
|---------|------|------|
| Layer 1: ミドルウェア | `/admin/*` 全体 | 既存 |
| Layer 2: ページ | 各Server Component | **今回追加** |
| Layer 3: Server Actions | 各mutation | 既存 |

## 変更ファイル

- `src/app/admin/orders/page.tsx`
- `src/app/admin/products/page.tsx`
- `src/app/admin/payment/page.tsx`
- `src/app/admin/legal/page.tsx`

## Test plan

- [ ] 管理者でログインして各ページが正常に表示されること
- [ ] 未ログイン状態で `/admin/orders` 等にアクセスするとログインページにリダイレクトされること
- [ ] ビルドが成功すること（確認済み）

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)