### PR TITLE
feat: CockroachDBからSupabase PostgreSQLに移行 (#200)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-# CockroachDB (local)
-DATABASE_URL=postgresql://root@localhost:26257/mikan_order?sslmode=disable
+# Supabase PostgreSQL
+# アプリ用（Transaction pooler）
+DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-1-ap-northeast-1.pooler.supabase.com:6543/postgres
+# マイグレーション用（Direct connection）
+DIRECT_URL=postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres
 
 # LIFF
 NEXT_PUBLIC_LIFF_ID=your-liff-id

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,16 @@
+name: Supabase Keepalive
+
+on:
+  schedule:
+    - cron: "0 0 */3 * *" # 3日おきにUTC 0:00に実行
+  workflow_dispatch: # 手動実行用
+
+jobs:
+  keepalive:
+    name: Ping Supabase databases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping dev database
+        run: psql "${{ secrets.SUPABASE_DEV_DATABASE_URL }}" -c "SELECT 1"
+      - name: Ping prod database
+        run: psql "${{ secrets.SUPABASE_PROD_DATABASE_URL }}" -c "SELECT 1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 services:
-  cockroachdb:
-    image: cockroachdb/cockroach:v24.3.0
-    command: start-single-node --insecure
+  postgres:
+    image: postgres:16
     ports:
-      - "26257:26257"
-      - "8081:8080"
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: mikan_order
     volumes:
-      - cockroach-data:/cockroach/cockroach-data
+      - postgres-data:/var/lib/postgresql/data
 volumes:
-  cockroach-data:
+  postgres-data:

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: "./src/db/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: process.env.DIRECT_URL ?? process.env.DATABASE_URL!,
   },
 });

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "happy-dom": "^20.8.4",
     "jsdom": "^29.0.1",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,6 +4,9 @@ import * as schema from "./schema";
 
 const connectionString = process.env.DATABASE_URL!;
 
-const client = postgres(connectionString);
+const client = postgres(connectionString, {
+  max: 1,
+  prepare: false,
+});
 
 export const db = drizzle(client, { schema });


### PR DESCRIPTION
## Summary
- CockroachDB（シンガポール）からSupabase PostgreSQL（東京リージョン）へDB移行
- サーバーレス向け接続プーリング設定（Transaction pooler + `max:1`, `prepare:false`）
- マイグレーション用Direct URL / アプリ用Pooled URLの使い分け
- Supabase Free Tier自動停止防止のkeepalive cronジョブ追加

## 背景
- CockroachDB Free Tierの月間RU制限到達により本番停止（#200）
- レイテンシ改善（シンガポール→東京）
- `drizzle-kit push` の `regtype` パースエラー解消

## 変更内容
| ファイル | 変更 |
|---------|------|
| `.env.example` | CockroachDB→Supabase形式 + `DIRECT_URL` 追加 |
| `docker-compose.yml` | CockroachDB→PostgreSQL 16 |
| `src/db/index.ts` | `max: 1`, `prepare: false`（サーバーレス対応） |
| `drizzle.config.ts` | `DIRECT_URL` 優先使用（マイグレーション用） |
| `package.json` | `tsx` devDependency追加 |
| `.github/workflows/supabase-keepalive.yml` | 3日おきのDB ping cron |

## 環境設定（コード外）
- [x] Supabase dev/prodプロジェクト作成（東京リージョン）
- [x] dev/prodスキーマ適用 + シードデータ投入
- [x] Vercel環境変数更新（Production/Preview）
- [x] GitHub Secrets更新（PRODUCTION_DATABASE_URL, SUPABASE_DEV/PROD_DATABASE_URL）

## Test plan
- [x] `pnpm test` 全344テストパス
- [x] `drizzle-kit push` dev/prod 両方成功
- [x] シードデータ投入 dev/prod 両方成功
- [ ] 本番デプロイ後の動作確認（商品一覧、カート、注文、管理画面）

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)